### PR TITLE
we can actually spawn the naga without crashing now

### DIFF
--- a/src/main/java/twilightforest/client/renderer/entity/RenderTFNagaSegment.java
+++ b/src/main/java/twilightforest/client/renderer/entity/RenderTFNagaSegment.java
@@ -29,10 +29,10 @@ public class RenderTFNagaSegment extends Render<EntityTFNagaSegment> {
     {
         GlStateManager.pushMatrix();
         GlStateManager.translate((float)par2, (float)par4, (float)par6);
-        GlStateManager.rotate(180 - MathHelper.wrapDegrees(par8), 0.0F, 1.0F, 0.0F);
+        GlStateManager.rotate(180 - MathHelper.wrapDegrees(par1Entity.rotationYaw), 0.0F, 1.0F, 0.0F); // Was par8 instead of par1Entity.rotationYaw
         
         // pitch
-        float pitch = par1Entity.prevRotationPitch + (par1Entity.rotationPitch - par1Entity.prevRotationPitch) * time;
+        float pitch = par1Entity.rotationPitch; // Was: par1Entity.prevRotationPitch + (par1Entity.rotationPitch - par1Entity.prevRotationPitch) * time;
         
         GlStateManager.rotate(pitch, 1.0F, 0.0F, 0.0F);
 

--- a/src/main/java/twilightforest/client/renderer/entity/RenderTFNagaSegment.java
+++ b/src/main/java/twilightforest/client/renderer/entity/RenderTFNagaSegment.java
@@ -29,10 +29,10 @@ public class RenderTFNagaSegment extends Render<EntityTFNagaSegment> {
     {
         GlStateManager.pushMatrix();
         GlStateManager.translate((float)par2, (float)par4, (float)par6);
-        GlStateManager.rotate(180 - MathHelper.wrapDegrees(par1Entity.rotationYaw), 0.0F, 1.0F, 0.0F); // Was par8 instead of par1Entity.rotationYaw
+        GlStateManager.rotate(180 - MathHelper.wrapDegrees(par1Entity.rotationYaw), 0.0F, 1.0F, 0.0F);
         
         // pitch
-        float pitch = par1Entity.rotationPitch; // Was: par1Entity.prevRotationPitch + (par1Entity.rotationPitch - par1Entity.prevRotationPitch) * time;
+        float pitch = par1Entity.rotationPitch;
         
         GlStateManager.rotate(pitch, 1.0F, 0.0F, 0.0F);
 

--- a/src/main/java/twilightforest/entity/boss/EntityTFNaga.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFNaga.java
@@ -1,12 +1,24 @@
 package twilightforest.entity.boss;
 
-import net.minecraft.entity.*;
-import net.minecraft.entity.ai.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.IEntityMultiPart;
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.EntityAIBase;
+import net.minecraft.entity.ai.EntityAIHurtByTarget;
+import net.minecraft.entity.ai.EntityAINearestAttackableTarget;
+import net.minecraft.entity.ai.EntityAISwimming;
+import net.minecraft.entity.ai.EntityAIWander;
+import net.minecraft.entity.ai.EntityMoveHelper;
 import net.minecraft.entity.boss.EntityDragonPart;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagIntArray;
 import net.minecraft.util.DamageSource;
@@ -27,11 +39,9 @@ import twilightforest.TwilightForestMod;
 import twilightforest.block.BlockTFBossSpawner;
 import twilightforest.block.TFBlocks;
 import twilightforest.block.enums.BossVariant;
-import twilightforest.item.TFItems;
 import twilightforest.world.ChunkGeneratorTwilightForest;
 import twilightforest.world.TFBiomeProvider;
 import twilightforest.world.TFWorld;
-import twilightforest.world.WorldProviderTwilightForest;
 
 
 public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
@@ -45,7 +55,7 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
 	private int currentSegmentCount = 0; // not including head
 	private final float healthPerSegment;
 	private final EntityTFNagaSegment[] body = new EntityTFNagaSegment[MAX_SEGMENTS];
-	private final AIMovementPattern movementAI = new AIMovementPattern(this);
+	private AIMovementPattern movementAI;
 	private int ticksSinceDamaged = 0;
 
 	public EntityTFNaga(World world) {
@@ -83,7 +93,7 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
 		this.tasks.addTask(1, new EntityAISwimming(this));
 		this.tasks.addTask(2, new AIAttack(this));
 		this.tasks.addTask(3, new AISmash(this));
-		this.tasks.addTask(4, movementAI);
+		this.tasks.addTask(4, movementAI = new AIMovementPattern(this));
 		this.tasks.addTask(8, new EntityAIWander(this, 1) {
 			@Override
 			public void startExecuting() {
@@ -322,7 +332,7 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
 	{
 		int oldSegments = this.currentSegmentCount;
 		int newSegments = MathHelper.clamp((int) ((this.getHealth() / healthPerSegment) + (getHealth() > 0 ? 2 : 0)), 0, MAX_SEGMENTS);
-
+		this.currentSegmentCount = newSegments; // spawnBodySegments() was using the spawnBodySegments which happened to be set after the call, so the segments never actually spawned. 
 		if (newSegments != oldSegments) {
 			if (newSegments < oldSegments) {
 				for (int i = newSegments; i < oldSegments; i++) {
@@ -336,7 +346,6 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
 			}
 		}
 
-		this.currentSegmentCount = newSegments;
 	}
 	
     @Override
@@ -650,16 +659,13 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
 
 	private void spawnBodySegments()
 	{
-		if (!world.isRemote)
+		for (int i = 0; i < currentSegmentCount; i++)
 		{
-			for (int i = 0; i < currentSegmentCount; i++)
+			if (body[i] == null || body[i].isDead)
 			{
-				if (body[i] == null || body[i].isDead)
-				{
-					body[i] = new EntityTFNagaSegment(this, i);
-					body[i].setLocationAndAngles(posX + 0.1 * i, posY + 0.5D, posZ + 0.1 * i, rand.nextFloat() * 360F, 0.0F);
-					world.spawnEntity(body[i]);
-				}
+				body[i] = new EntityTFNagaSegment(this, i);
+				body[i].setLocationAndAngles(posX + 0.1 * i, posY + 0.5D, posZ + 0.1 * i, rand.nextFloat() * 360F, 0.0F);
+				if (!world.isRemote) world.spawnEntity(body[i]); // Moved the !world.isRemote check here as the segments were not spawning on the client side otherwise for some reason.
 			}
 		}
 	}
@@ -777,6 +783,8 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
     @Override
     public Entity[] getParts()
     {
-        return body;
+    	List<EntityTFNagaSegment> list = new ArrayList<EntityTFNagaSegment>(Arrays.asList(body));
+    	list.removeAll(Collections.singleton(null));
+    	return list.toArray(new EntityTFNagaSegment[list.size()]); // This cannot contain nulls
     }
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFNaga.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFNaga.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -332,7 +333,7 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
 	{
 		int oldSegments = this.currentSegmentCount;
 		int newSegments = MathHelper.clamp((int) ((this.getHealth() / healthPerSegment) + (getHealth() > 0 ? 2 : 0)), 0, MAX_SEGMENTS);
-		this.currentSegmentCount = newSegments; // spawnBodySegments() was using the currentSegmentCount which happened to be set after the call, so the segments never actually spawned. 
+		this.currentSegmentCount = newSegments;
 		if (newSegments != oldSegments) {
 			if (newSegments < oldSegments) {
 				for (int i = newSegments; i < oldSegments; i++) {
@@ -665,7 +666,7 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
 			{
 				body[i] = new EntityTFNagaSegment(this, i);
 				body[i].setLocationAndAngles(posX + 0.1 * i, posY + 0.5D, posZ + 0.1 * i, rand.nextFloat() * 360F, 0.0F);
-				if (!world.isRemote) world.spawnEntity(body[i]); // Moved the !world.isRemote check here as the segments were not spawning on the client side otherwise for some reason.
+				if (!world.isRemote) world.spawnEntity(body[i]);
 			}
 		}
 	}
@@ -783,8 +784,6 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
     @Override
     public Entity[] getParts()
     {
-    	List<EntityTFNagaSegment> list = new ArrayList<EntityTFNagaSegment>(Arrays.asList(body));
-    	list.removeAll(Collections.singleton(null));
-    	return list.toArray(new EntityTFNagaSegment[list.size()]); // This cannot contain nulls
+    	return Arrays.stream(body).filter(Objects::nonNull).toArray(Entity[]::new);
     }
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFNaga.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFNaga.java
@@ -332,7 +332,7 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
 	{
 		int oldSegments = this.currentSegmentCount;
 		int newSegments = MathHelper.clamp((int) ((this.getHealth() / healthPerSegment) + (getHealth() > 0 ? 2 : 0)), 0, MAX_SEGMENTS);
-		this.currentSegmentCount = newSegments; // spawnBodySegments() was using the spawnBodySegments which happened to be set after the call, so the segments never actually spawned. 
+		this.currentSegmentCount = newSegments; // spawnBodySegments() was using the currentSegmentCount which happened to be set after the call, so the segments never actually spawned. 
 		if (newSegments != oldSegments) {
 			if (newSegments < oldSegments) {
 				for (int i = newSegments; i < oldSegments; i++) {

--- a/src/main/java/twilightforest/entity/boss/EntityTFNagaSegment.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFNagaSegment.java
@@ -7,7 +7,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
-import net.minecraft.entity.boss.EntityDragonPart;
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
@@ -15,8 +14,6 @@ import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class EntityTFNagaSegment extends Entity {
 	private EntityTFNaga naga;

--- a/src/main/resources/assets/twilightforest/loot_tables/entities/naga.json
+++ b/src/main/resources/assets/twilightforest/loot_tables/entities/naga.json
@@ -15,7 +15,7 @@
       "entries": [{
         "type": "item",
         "name": "twilightforest:trophy",
-        "functions": [{ "function": "set_data", "data": 1 }]
+        "functions": [{ "function": "set_data", "data": 0 }]
       }]
     }
   ]


### PR DESCRIPTION
This is to close #7  
Things to note:
- Because fields are initialized AFTER the super in the constructor I had to initialize 'movementAI' within 'initEntityAI' and remove the 'final' (do we really need it though)
- 'getParts()' was also crashing because vanilla doesnt check for nulls, so I just did a copy of our 'body' array without the nulls.
- The segment render was really wonky, as in rotating in an odd jaggy way, I changed it to use 'rotationYaw' and 'rotationPitch' instead which seems pretty smooth to me. I left the old code commented out incase you guys wanted to revert and fix it if there's a proper way.
- Fixed which trophy drops, was the lich before.
- Stuff is still broken/needs work such as AI that I'll leave to you guys since well.. i'm not that great at it :P
- Rest of the changes all should have comments next to them. Feel free to change/expand upon this as I just wanted to make the naga spawnable.