### PR TITLE
ghast fixes

### DIFF
--- a/src/main/java/twilightforest/client/renderer/entity/RenderTFTowerGhast.java
+++ b/src/main/java/twilightforest/client/renderer/entity/RenderTFTowerGhast.java
@@ -27,9 +27,9 @@ public class RenderTFTowerGhast extends RenderTFGhast<EntityTFTowerGhast> {
     @Override
     protected void preRenderCallback(EntityTFTowerGhast par1EntityLiving, float partialTicks)
     {
-        EntityTFTowerGhast.AIAttack attackAI = par1EntityLiving.attackAI;
-        float scaleVariable = (attackAI.prevAttackTimer + (attackAI.attackTimer - attackAI.prevAttackTimer) * partialTicks) / 20.0F;
-
+        int attackTimer = par1EntityLiving.getAttackTimer();
+        int prevAttackTimer = par1EntityLiving.getPrevAttackTimer();
+        float scaleVariable = (prevAttackTimer + (attackTimer - prevAttackTimer) * partialTicks) / 20.0F;
         if (scaleVariable < 0.0F)
         {
             scaleVariable = 0.0F;

--- a/src/main/java/twilightforest/entity/EntityTFMiniGhast.java
+++ b/src/main/java/twilightforest/entity/EntityTFMiniGhast.java
@@ -40,13 +40,17 @@ public class EntityTFMiniGhast extends EntityTFTowerGhast
         this.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(this.isMinion ? 6 : 10);
         this.getEntityAttribute(SharedMonsterAttributes.FOLLOW_RANGE).setBaseValue(16.0D);
     }
+	
+	@Override
+	public float getEyeHeight() {
+		return 1.2F;
+	}
     
     // Loosely based on EntityEnderman.shouldAttackPlayer
     @Override
     protected boolean shouldAttack(EntityLivingBase living)
     {
         ItemStack helmet = living.getItemStackFromSlot(EntityEquipmentSlot.HEAD);
-
         if (!helmet.isEmpty() && helmet.getItem() == Item.getItemFromBlock(Blocks.PUMPKIN))
         {
             return false;

--- a/src/main/java/twilightforest/entity/boss/EntityTFUrGhast.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFUrGhast.java
@@ -44,7 +44,7 @@ public class EntityTFUrGhast extends EntityTFTowerGhast {
 	//private static final int CRUISING_ALTITUDE = 235; // absolute cruising altitude
 	private static final int HOVER_ALTITUDE = 20; // how far, relatively, do we hover over ghast traps?
 
-    private final List<BlockPos> trapLocations = new ArrayList<>();
+    private List<BlockPos> trapLocations;
     private int nextTantrumCry;
     
     private float damageUntilNextPhase = 45; // how much damage can we take before we toggle tantrum mode
@@ -79,6 +79,7 @@ public class EntityTFUrGhast extends EntityTFTowerGhast {
     @Override
 	protected void initEntityAI() {
 		super.initEntityAI();
+		trapLocations = new ArrayList<BlockPos>();
 		this.tasks.taskEntries.removeIf(e -> e.action instanceof EntityTFTowerGhast.AIHomedFly);
 		this.tasks.addTask(5, new AIWaypointFly(this));
 	}
@@ -86,11 +87,12 @@ public class EntityTFUrGhast extends EntityTFTowerGhast {
 	static class AIWaypointFly extends EntityAIBase {
 		private final EntityTFUrGhast taskOwner;
 
-		private final List<BlockPos> pointsToVisit = createPath();
+		private final List<BlockPos> pointsToVisit;
 		private int currentPoint = 0;
 
 		AIWaypointFly(EntityTFUrGhast ghast) {
 			this.taskOwner = ghast;
+			pointsToVisit = createPath();
 			setMutexBits(1);
 		}
 
@@ -232,7 +234,7 @@ public class EntityTFUrGhast extends EntityTFTowerGhast {
         	attackSuccessful = super.attackEntityFrom(source, damage);
         }
 
-        float lastDamage = getHealth() - oldHealth;
+        float lastDamage = oldHealth - getHealth();
  
         if (!world.isRemote)
         {


### PR DESCRIPTION
Things to note:
- Fixed the rendering, they're no longer invisible and swell when they attack.
- Few fields had to be initialized elsewhere or else they would be null when called, same issue the Naga had.
- The Ur-Ghast can actually enter a tantrum now, values were being subtracted wrong...
- Lowered the Eye Height of the MiniGhast for when players look at the model the ghast actually attacks instead of looking way above it. Feel free to adjust this value.
- Copied over AIRandomFly from EntityGhast for ghast movement (except the Ur-Ghast as this has its own system) which uses `wanderFactor` and a check to see if we have a target, if so we stop moving.
- Removed setMutexBits from AIAttack as it was conflicting with EntityGhast.AILookAround which caused all ghasts to not attack at all.
- Added a shouldAttack to AIAttack and some other checks elsewhere in EntityTFTowerGhast so that the MiniGhast doesnt enter its attack animation unless it's actually attacking.
- The ParticleGhastTear render is broken still.
- The Ur-Ghast still isn't using `wanderFactor` for movement, I don't really know how you guys want to go about this.