### PR TITLE
Fixed custom smoke scale

### DIFF
--- a/src/main/java/twilightforest/client/TFClientProxy.java
+++ b/src/main/java/twilightforest/client/TFClientProxy.java
@@ -18,17 +18,7 @@ import twilightforest.TFCommonProxy;
 import twilightforest.TwilightForestMod;
 import twilightforest.block.ColorHandler;
 import twilightforest.client.model.*;
-import twilightforest.client.particle.ParticleAnnihilate;
-import twilightforest.client.particle.ParticleGhastTear;
-import twilightforest.client.particle.ParticleGhastTrap;
-import twilightforest.client.particle.ParticleIceBeam;
-import twilightforest.client.particle.ParticleLargeFlame;
-import twilightforest.client.particle.ParticleLeafRune;
-import twilightforest.client.particle.ParticleProtection;
-import twilightforest.client.particle.ParticleSnow;
-import twilightforest.client.particle.ParticleSnowGuardian;
-import twilightforest.client.particle.ParticleSnowWarning;
-import twilightforest.client.particle.TFParticleType;
+import twilightforest.client.particle.*;
 import twilightforest.client.renderer.TileEntityTFCicadaRenderer;
 import twilightforest.client.renderer.TileEntityTFFireflyRenderer;
 import twilightforest.client.renderer.TileEntityTFMoonwormRenderer;
@@ -294,7 +284,7 @@ public class TFClientProxy extends TFCommonProxy {
 						particle = new ParticleAnnihilate(world, x, y, z, velX, velY, velZ, 0.75F);
 						break;
 					case HUGE_SMOKE:
-						world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, x, y, z, velX, velY, velZ, 8);
+						particle = new ParticleSmokeScale(world, x, y, z, velX, velY, velZ, 8);
 				}
 
 				if (particle != null) {

--- a/src/main/java/twilightforest/client/TFClientProxy.java
+++ b/src/main/java/twilightforest/client/TFClientProxy.java
@@ -284,7 +284,7 @@ public class TFClientProxy extends TFCommonProxy {
 						particle = new ParticleAnnihilate(world, x, y, z, velX, velY, velZ, 0.75F);
 						break;
 					case HUGE_SMOKE:
-						particle = new ParticleSmokeScale(world, x, y, z, velX, velY, velZ, 8);
+						particle = new ParticleSmokeScale(world, x, y, z, velX, velY, velZ, 4.0F + world.rand.nextFloat());
 				}
 
 				if (particle != null) {

--- a/src/main/java/twilightforest/client/particle/ParticleSmokeScale.java
+++ b/src/main/java/twilightforest/client/particle/ParticleSmokeScale.java
@@ -1,0 +1,12 @@
+package twilightforest.client.particle;
+
+import net.minecraft.client.particle.ParticleEnchantmentTable;
+import net.minecraft.client.particle.ParticleSmokeNormal;
+import net.minecraft.world.World;
+
+public class ParticleSmokeScale extends ParticleSmokeNormal {
+
+	public ParticleSmokeScale(World world, double x, double y, double z, double velX, double velY, double velZ, float scale) {
+		super(world, x, y, z, velX, velY, velZ, scale);
+	}
+}


### PR DESCRIPTION
A fix for #114 
Both `ParticleSmokeLarge` and `ParticleSmokeNormal` use hardcoded scale values that we cannot alter so I went ahead and created our own `ParticleSmokeScale` that'll allow us to use a custom scale value.

I've also changed our value from 8 to a random float value between 4.0F and 5.0F as per request from @Drullkus 