### PR TITLE
Hydra can no longer push itself

### DIFF
--- a/src/main/java/twilightforest/entity/boss/EntityTFHydra.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFHydra.java
@@ -672,6 +672,11 @@ public class EntityTFHydra extends EntityLiving implements IEntityMultiPart, IMo
 	}
 
 	@Override
+	protected void collideWithEntity(Entity entityIn) {
+
+	}
+
+	@Override
 	public void knockBack(Entity entity, float i, double d, double d1) {
 	}
 


### PR DESCRIPTION
Fixes #102 

So it turns out the Hydra was walking around due to its parts actually colliding with the hydra and pushing it in random directions. I went ahead and disabled it for all entities instead of just checking for the parts as I feel you shouldn't be able to push around a massive beast such as the Hydra so easily just by walking into him.

However, this doesn't push away the player any more either and if we want to keep that aspect we could override `applyEntityCollision` instead. The downside to pushing the player away though is that it makes it nearly impossible for them to get close enough to deal damage to the Hydra directly if they wish to do so as you were able to in past versions. The Hydra does after all have specific attacks that fire (or rather... bite) only when the target is close enough.