### PR TITLE
Potential fix for Issue #164 (Enabled group killing of bosses)

### DIFF
--- a/src/main/java/twilightforest/TFAdvancements.java
+++ b/src/main/java/twilightforest/TFAdvancements.java
@@ -14,6 +14,7 @@ public class TFAdvancements {
     public static final HydraChopTrigger CONSUME_HYDRA_CHOP = CriteriaTriggers.register(new HydraChopTrigger());
     public static final QuestRamCompletionTrigger QUEST_RAM_COMPLETED = CriteriaTriggers.register(new QuestRamCompletionTrigger());
     public static final TrophyPedestalTrigger PLACED_TROPHY_ON_PEDESTAL = CriteriaTriggers.register(new TrophyPedestalTrigger());
+    public static final GroupKillTrigger GANG_BANG = CriteriaTriggers.register(new GroupKillTrigger());
 
     public static void init() {
     }

--- a/src/main/java/twilightforest/advancements/GroupKillTrigger.java
+++ b/src/main/java/twilightforest/advancements/GroupKillTrigger.java
@@ -1,0 +1,177 @@
+package twilightforest.advancements;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.advancements.ICriterionTrigger;
+import net.minecraft.advancements.PlayerAdvancements;
+import net.minecraft.advancements.critereon.AbstractCriterionInstance;
+import net.minecraft.advancements.critereon.DamagePredicate;
+import net.minecraft.advancements.critereon.EntityPredicate;
+import net.minecraft.advancements.critereon.MinMaxBounds;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.CombatEntry;
+import net.minecraft.util.JsonUtils;
+import net.minecraft.util.ResourceLocation;
+import twilightforest.TwilightForestMod;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.*;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+public class GroupKillTrigger implements ICriterionTrigger<GroupKillTrigger.Instance> {
+    private static final ResourceLocation ID = new ResourceLocation(TwilightForestMod.ID, "player_group_killed_entity");
+    private final Map<PlayerAdvancements, GroupKillTrigger.Listeners> listeners = Maps.newHashMap();
+
+    @Override
+    public ResourceLocation getId() {
+        return ID;
+    }
+
+    @Override
+    public void addListener(PlayerAdvancements playerAdvancementsIn, Listener<Instance> listener) {
+        GroupKillTrigger.Listeners listeners = this.listeners.computeIfAbsent(playerAdvancementsIn, Listeners::new);
+
+        listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(PlayerAdvancements playerAdvancementsIn, ICriterionTrigger.Listener<GroupKillTrigger.Instance> listener) {
+        GroupKillTrigger.Listeners listeners = this.listeners.get(playerAdvancementsIn);
+
+        if (listeners != null)
+        {
+            listeners.remove(listener);
+
+            if (listeners.isEmpty())
+            {
+                this.listeners.remove(playerAdvancementsIn);
+            }
+        }
+    }
+
+    @Override
+    public void removeAllListeners(PlayerAdvancements playerAdvancementsIn) {
+        this.listeners.remove(playerAdvancementsIn);
+    }
+
+    @Override
+    public Instance deserializeInstance(JsonObject json, JsonDeserializationContext context) {
+        return new GroupKillTrigger.Instance(
+                JsonUtils.getFloat(json,"damage_threshold_denominator"),
+                EntityPredicate.deserialize(json.get("entity_killed")),
+                DamagePredicate.deserialize(json.get("required_attack_type")),
+                SimpleConditionalPredicate.deserialize(json, "comparator"),
+                MinMaxBounds.deserialize(json.get("player_amount")));
+    }
+
+    public void trigger(EntityPlayerMP player, EntityLivingBase entityNotLivingAnymore, List<CombatEntry> listOfAllOffenses, int playerCount) {
+        Listeners l = listeners.get(player.getAdvancements());
+        if (l != null) {
+            l.trigger(player, entityNotLivingAnymore, listOfAllOffenses, playerCount);
+        }
+    }
+
+    static class Instance extends AbstractCriterionInstance {
+        private final float damageThreshold;
+        private final EntityPredicate entityToKill;
+        private final DamagePredicate damagePredicateRequirement;
+        private final SimpleConditionalPredicate comparator;
+        private final MinMaxBounds playerAmountRequired;
+
+        Instance(float damageThreshold, EntityPredicate entityToKill, DamagePredicate damagePredicateRequirement, SimpleConditionalPredicate comparator, MinMaxBounds playerAmountRequired) {
+            super(GroupKillTrigger.ID);
+            this.damageThreshold = damageThreshold;
+            this.entityToKill = entityToKill;
+            this.damagePredicateRequirement = damagePredicateRequirement;
+            this.comparator = comparator;
+            this.playerAmountRequired = playerAmountRequired;
+        }
+
+        boolean test(EntityPlayerMP player, EntityLivingBase entityNotLivingAnymore, List<CombatEntry> listOfAllOffenses, int playerCount) {
+            if (entityToKill.test(player, entityNotLivingAnymore) && playerAmountRequired.test(playerCount)) {
+                boolean boolAcculumator = comparator == SimpleConditionalPredicate.AND; // That way, we don't trip as automatic-pass if OR, or automatic-fail if AND
+                float damageAccumulator = 0;
+
+                for (CombatEntry entry : listOfAllOffenses) {
+                    if (!(comparator == SimpleConditionalPredicate.OR && boolAcculumator)) // Basically, if we've already got true on OR, then we don't want to waste more processing on further comparing
+                        boolAcculumator = comparator.compare(boolAcculumator, damagePredicateRequirement.test(player, entry.getDamageSrc(), entry.getDamage(), entry.getDamage(), false));
+
+                    System.out.println("damages:" + damageAccumulator);
+
+                    damageAccumulator += entry.getDamage();
+                }
+
+                System.out.println(damageAccumulator + " > (" + "(" + entityNotLivingAnymore.getMaxHealth() + "/" + playerCount + ")/" + damageThreshold + ") = " + ((entityNotLivingAnymore.getMaxHealth()/(float) playerCount)/damageThreshold) + ")");
+
+                return boolAcculumator && damageAccumulator > (entityNotLivingAnymore.getMaxHealth()/(float) playerCount)/damageThreshold;
+            }
+            return false;
+        }
+    }
+
+    private static class Listeners {
+        private final PlayerAdvancements playerAdvancements;
+        private final Set<Listener<GroupKillTrigger.Instance>> listeners = Sets.newHashSet();
+
+        Listeners(PlayerAdvancements playerAdvancements) {
+            this.playerAdvancements = playerAdvancements;
+        }
+
+        public boolean isEmpty() {
+            return this.listeners.isEmpty();
+        }
+
+        public void add(ICriterionTrigger.Listener<GroupKillTrigger.Instance> listener) {
+            this.listeners.add(listener);
+        }
+
+        public void remove(ICriterionTrigger.Listener<GroupKillTrigger.Instance> listener) {
+            this.listeners.remove(listener);
+        }
+
+        public void trigger(EntityPlayerMP player, EntityLivingBase entityNotLivingAnymore, List<CombatEntry> listOfAllOffenses, int playerCount) {
+            List<Listener<GroupKillTrigger.Instance>> list = new ArrayList<>();
+
+            for (ICriterionTrigger.Listener<GroupKillTrigger.Instance> listener : this.listeners)
+                if (listener.getCriterionInstance().test(player, entityNotLivingAnymore, listOfAllOffenses, playerCount))
+                    list.add(listener);
+
+            for (ICriterionTrigger.Listener<GroupKillTrigger.Instance> listener : list)
+                listener.grantCriterion(this.playerAdvancements);
+        }
+    }
+
+    private enum SimpleConditionalPredicate {
+        AND((a, b) -> a && b),
+        OR((a, b) -> a || b);
+
+        private final ITeenyComparator comparator;
+        public boolean compare(boolean a, boolean b) {
+            return this.comparator.compare(a, b);
+        }
+
+        SimpleConditionalPredicate(ITeenyComparator comparator) {
+            this.comparator = comparator;
+        }
+
+        public static SimpleConditionalPredicate deserialize(@Nullable JsonElement element, String targetString) {
+            try {
+                return SimpleConditionalPredicate.valueOf(JsonUtils.getString(element, targetString).toUpperCase(Locale.ROOT));
+            } catch (Exception justTakeIt) {
+                TwilightForestMod.LOGGER.warn("Looks like you almost lost a bunch of advancements. The problem was caught for you. Git gud. Fix whatever advancement that uses \"twilightforest:player_group_killed_entity\" yourself please.\n" + justTakeIt);
+                return OR;
+            }
+        }
+    }
+
+    private interface ITeenyComparator {
+        boolean compare(boolean a, boolean b);
+    }
+}

--- a/src/main/java/twilightforest/entity/EntityTFAdherent.java
+++ b/src/main/java/twilightforest/entity/EntityTFAdherent.java
@@ -18,11 +18,15 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 
+import java.util.ArrayList;
+import java.util.List;
 
-public class EntityTFAdherent extends EntityMob implements IRangedAttackMob, ITFCharger {
+
+public class EntityTFAdherent extends EntityMob implements IRangedAttackMob, ITFCharger, ISavedCombatEntriesOnDeath {
 
 	private static final DataParameter<Boolean> CHARGE_FLAG = EntityDataManager.createKey(EntityTFAdherent.class, DataSerializers.BOOLEAN);
 
@@ -87,5 +91,16 @@ public class EntityTFAdherent extends EntityMob implements IRangedAttackMob, ITF
 		dataManager.set(CHARGE_FLAG, flag);
 	}
 
+	private ArrayList<CombatEntry> combatList;
 
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFBlockGoblin.java
+++ b/src/main/java/twilightforest/entity/EntityTFBlockGoblin.java
@@ -20,18 +20,16 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumHand;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import twilightforest.TFSounds;
 import twilightforest.TwilightForestMod;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public class EntityTFBlockGoblin extends EntityMob implements IEntityMultiPart {
+public class EntityTFBlockGoblin extends EntityMob implements IEntityMultiPart, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/block_goblin");
 	private static final float CHAIN_SPEED = 16F;
 	private static final DataParameter<Byte> DATA_CHAINLENGTH = EntityDataManager.createKey(EntityTFBlockGoblin.class, DataSerializers.BYTE);
@@ -258,5 +256,18 @@ public class EntityTFBlockGoblin extends EntityMob implements IEntityMultiPart {
 	@Override
 	public Entity[] getParts() {
 		return partsArray;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFBoggard.java
+++ b/src/main/java/twilightforest/entity/EntityTFBoggard.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.ai.EntityAIWatchClosest;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -22,8 +23,11 @@ import twilightforest.TwilightForestMod;
 import twilightforest.entity.ai.EntityAITFChargeAttack;
 import twilightforest.util.PlayerHelper;
 
+import java.util.ArrayList;
+import java.util.List;
 
-public class EntityTFBoggard extends EntityMob {
+
+public class EntityTFBoggard extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/boggard");
 
 	public EntityTFBoggard(World world) {
@@ -83,5 +87,18 @@ public class EntityTFBoggard extends EntityMob {
 				PlayerHelper.grantCriterion((EntityPlayerMP) source.getTrueSource(), new ResourceLocation(TwilightForestMod.ID, "hill1"), "boggard");
 			}
 		}
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFDeathTome.java
+++ b/src/main/java/twilightforest/entity/EntityTFDeathTome.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.Items;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
@@ -21,7 +22,10 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import twilightforest.TwilightForestMod;
 
-public class EntityTFDeathTome extends EntityMob implements IRangedAttackMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFDeathTome extends EntityMob implements IRangedAttackMob, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/death_tome");
 
 	public EntityTFDeathTome(World par1World) {
@@ -91,4 +95,17 @@ public class EntityTFDeathTome extends EntityMob implements IRangedAttackMob {
 
 	@Override
 	public void setSwingingArms(boolean swingingArms) {} // todo 1.12
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFFireBeetle.java
+++ b/src/main/java/twilightforest/entity/EntityTFFireBeetle.java
@@ -15,10 +15,7 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -27,8 +24,11 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import twilightforest.TwilightForestMod;
 import twilightforest.entity.ai.EntityAITFBreathAttack;
 
+import java.util.ArrayList;
+import java.util.List;
 
-public class EntityTFFireBeetle extends EntityMob implements IBreathAttacker {
+
+public class EntityTFFireBeetle extends EntityMob implements IBreathAttacker, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/fire_beetle");
 	private static final DataParameter<Boolean> BREATHING = EntityDataManager.createKey(EntityTFFireBeetle.class, DataSerializers.BOOLEAN);
 	private static final int BREATH_DURATION = 10;
@@ -163,4 +163,16 @@ public class EntityTFFireBeetle extends EntityMob implements IBreathAttacker {
 		}
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFGiantMiner.java
+++ b/src/main/java/twilightforest/entity/EntityTFGiantMiner.java
@@ -15,12 +15,16 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.World;
 import twilightforest.TwilightForestMod;
 
-public class EntityTFGiantMiner extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFGiantMiner extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/giant_miner");
 
 	public EntityTFGiantMiner(World par1World) {
@@ -67,5 +71,18 @@ public class EntityTFGiantMiner extends EntityMob {
 	@Override
 	public ResourceLocation getLootTable() {
 		return LOOT_TABLE;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFGoblinKnightLower.java
+++ b/src/main/java/twilightforest/entity/EntityTFGoblinKnightLower.java
@@ -20,13 +20,17 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.World;
 import twilightforest.entity.ai.EntityAITFRiderSpearAttack;
 
-public class EntityTFGoblinKnightLower extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFGoblinKnightLower extends EntityMob implements ISavedCombatEntriesOnDeath {
 	private static final DataParameter<Boolean> ARMOR = EntityDataManager.createKey(EntityTFGoblinKnightLower.class, DataSerializers.BOOLEAN);
 	private static final AttributeModifier ARMOR_MODIFIER = new AttributeModifier("Armor boost", 17, 0).setSaved(false);
 
@@ -181,4 +185,16 @@ public class EntityTFGoblinKnightLower extends EntityMob {
 		this.setHasArmor(false);
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFGoblinKnightUpper.java
+++ b/src/main/java/twilightforest/entity/EntityTFGoblinKnightUpper.java
@@ -20,10 +20,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumHand;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
@@ -33,9 +30,10 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import twilightforest.TwilightForestMod;
 import twilightforest.entity.ai.EntityAITFHeavySpearAttack;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public class EntityTFGoblinKnightUpper extends EntityMob {
+public class EntityTFGoblinKnightUpper extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/goblin_knight");
 	private static final int SHIELD_DAMAGE_THRESHOLD = 10;
 	private static final DataParameter<Byte> DATA_EQUIP = EntityDataManager.createKey(EntityTFGoblinKnightUpper.class, DataSerializers.BYTE);
@@ -317,5 +315,18 @@ public class EntityTFGoblinKnightUpper extends EntityMob {
 	@Override
 	public ResourceLocation getLootTable() {
 		return LOOT_TABLE;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFHarbingerCube.java
+++ b/src/main/java/twilightforest/entity/EntityTFHarbingerCube.java
@@ -9,10 +9,14 @@ import net.minecraft.entity.ai.EntityAIWander;
 import net.minecraft.entity.ai.EntityAIWatchClosest;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.world.World;
 
+import java.util.ArrayList;
+import java.util.List;
 
-public class EntityTFHarbingerCube extends EntityMob {
+
+public class EntityTFHarbingerCube extends EntityMob implements ISavedCombatEntriesOnDeath {
 
 	public EntityTFHarbingerCube(World world) {
 		super(world);
@@ -34,5 +38,18 @@ public class EntityTFHarbingerCube extends EntityMob {
 		super.applyEntityAttributes();
 		this.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(40.0D);
 		this.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).setBaseValue(0.23D);
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFHedgeSpider.java
+++ b/src/main/java/twilightforest/entity/EntityTFHedgeSpider.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.ai.EntityAINearestAttackableTarget;
 import net.minecraft.entity.monster.EntitySpider;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -14,12 +15,15 @@ import twilightforest.TFFeature;
 import twilightforest.TwilightForestMod;
 import twilightforest.util.PlayerHelper;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * The hedge spider is just like a normal spider, but it can spawn in the daytime.
  *
  * @author Ben
  */
-public class EntityTFHedgeSpider extends EntitySpider {
+public class EntityTFHedgeSpider extends EntitySpider implements ISavedCombatEntriesOnDeath {
 
 	public EntityTFHedgeSpider(World world) {
 		super(world);
@@ -67,5 +71,18 @@ public class EntityTFHedgeSpider extends EntitySpider {
 				PlayerHelper.grantCriterion((EntityPlayerMP) source.getTrueSource(), new ResourceLocation(TwilightForestMod.ID, "hedge"), "hedge_spider");
 			}
 		}
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFHelmetCrab.java
+++ b/src/main/java/twilightforest/entity/EntityTFHelmetCrab.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.ai.EntityAIWatchClosest;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -21,7 +22,10 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import twilightforest.TwilightForestMod;
 
-public class EntityTFHelmetCrab extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFHelmetCrab extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/helmet_crab");
 
 	public EntityTFHelmetCrab(World world) {
@@ -78,5 +82,18 @@ public class EntityTFHelmetCrab extends EntityMob {
 	@Override
 	public EnumCreatureAttribute getCreatureAttribute() {
 		return EnumCreatureAttribute.ARTHROPOD;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFHostileWolf.java
+++ b/src/main/java/twilightforest/entity/EntityTFHostileWolf.java
@@ -7,6 +7,7 @@ import net.minecraft.entity.passive.EntityWolf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -15,8 +16,11 @@ import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import twilightforest.TFFeature;
 
+import java.util.ArrayList;
+import java.util.List;
 
-public class EntityTFHostileWolf extends EntityWolf implements IMob {
+
+public class EntityTFHostileWolf extends EntityWolf implements IMob, ISavedCombatEntriesOnDeath {
 
 	public EntityTFHostileWolf(World world) {
 		super(world);
@@ -91,4 +95,16 @@ public class EntityTFHostileWolf extends EntityWolf implements IMob {
 		return false;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFIceExploder.java
+++ b/src/main/java/twilightforest/entity/EntityTFIceExploder.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.EnumDyeColor;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -26,7 +27,10 @@ import twilightforest.TwilightForestMod;
 import twilightforest.block.TFBlocks;
 import twilightforest.client.particle.TFParticleType;
 
-public class EntityTFIceExploder extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFIceExploder extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/ice_exploder");
 	private static final float EXPLOSION_RADIUS = 1;
 
@@ -196,5 +200,18 @@ public class EntityTFIceExploder extends EntityMob {
 	@Override
 	public int getMaxSpawnedInChunk() {
 		return 8;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFIceShooter.java
+++ b/src/main/java/twilightforest/entity/EntityTFIceShooter.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.ai.EntityAIWatchClosest;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -22,7 +23,10 @@ import twilightforest.TFSounds;
 import twilightforest.TwilightForestMod;
 import twilightforest.client.particle.TFParticleType;
 
-public class EntityTFIceShooter extends EntityMob implements IRangedAttackMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFIceShooter extends EntityMob implements IRangedAttackMob, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/ice_shooter");
 
 	public EntityTFIceShooter(World par1World) {
@@ -110,4 +114,17 @@ public class EntityTFIceShooter extends EntityMob implements IRangedAttackMob {
 
 	@Override
 	public void setSwingingArms(boolean swingingArms) {}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFKingSpider.java
+++ b/src/main/java/twilightforest/entity/EntityTFKingSpider.java
@@ -3,10 +3,14 @@ package twilightforest.entity;
 import net.minecraft.entity.IEntityLivingData;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.monster.EntitySpider;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.World;
 
-public class EntityTFKingSpider extends EntitySpider {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFKingSpider extends EntitySpider implements ISavedCombatEntriesOnDeath {
 
 	public EntityTFKingSpider(World world) {
 		super(world);
@@ -57,4 +61,16 @@ public class EntityTFKingSpider extends EntitySpider {
 		return (double) this.height * 0.75D;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFKobold.java
+++ b/src/main/java/twilightforest/entity/EntityTFKobold.java
@@ -14,18 +14,18 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.world.World;
 import twilightforest.TFSounds;
 import twilightforest.TwilightForestMod;
 import twilightforest.entity.ai.EntityAITFFlockToSameKind;
 import twilightforest.entity.ai.EntityAITFPanicOnFlockDeath;
 
+import java.util.ArrayList;
+import java.util.List;
 
-public class EntityTFKobold extends EntityMob {
+
+public class EntityTFKobold extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/kobold");
 	private static final DataParameter<Boolean> PANICKED = EntityDataManager.createKey(EntityTFKobold.class, DataSerializers.BOOLEAN);
 
@@ -105,5 +105,18 @@ public class EntityTFKobold extends EntityMob {
 	@Override
 	public int getMaxSpawnedInChunk() {
 		return 8;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFLoyalZombie.java
+++ b/src/main/java/twilightforest/entity/EntityTFLoyalZombie.java
@@ -1,22 +1,8 @@
 package twilightforest.entity;
 
 import net.minecraft.block.Block;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityAgeable;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.EnumCreatureAttribute;
-import net.minecraft.entity.SharedMonsterAttributes;
-import net.minecraft.entity.ai.EntityAIAttackMelee;
-import net.minecraft.entity.ai.EntityAIFollowOwner;
-import net.minecraft.entity.ai.EntityAIHurtByTarget;
-import net.minecraft.entity.ai.EntityAILeapAtTarget;
-import net.minecraft.entity.ai.EntityAILookIdle;
-import net.minecraft.entity.ai.EntityAINearestAttackableTarget;
-import net.minecraft.entity.ai.EntityAIOwnerHurtByTarget;
-import net.minecraft.entity.ai.EntityAIOwnerHurtTarget;
-import net.minecraft.entity.ai.EntityAISwimming;
-import net.minecraft.entity.ai.EntityAIWanderAvoidWater;
-import net.minecraft.entity.ai.EntityAIWatchClosest;
+import net.minecraft.entity.*;
+import net.minecraft.entity.ai.*;
 import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.entity.monster.EntityGhast;
 import net.minecraft.entity.monster.EntityMob;
@@ -26,13 +12,17 @@ import net.minecraft.entity.passive.EntityTameable;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.MobEffects;
 import net.minecraft.init.SoundEvents;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import java.util.ArrayList;
+import java.util.List;
 
-public class EntityTFLoyalZombie extends EntityTameable {
+
+public class EntityTFLoyalZombie extends EntityTameable implements ISavedCombatEntriesOnDeath {
 
 	public EntityTFLoyalZombie(World par1World) {
 		super(par1World);
@@ -134,5 +124,18 @@ public class EntityTFLoyalZombie extends EntityTameable {
 	@Override
 	public EnumCreatureAttribute getCreatureAttribute() {
 		return EnumCreatureAttribute.UNDEAD;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFMazeSlime.java
+++ b/src/main/java/twilightforest/entity/EntityTFMazeSlime.java
@@ -5,6 +5,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.monster.EntitySlime;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -17,7 +18,10 @@ import twilightforest.block.BlockTFMazestone;
 import twilightforest.block.TFBlocks;
 import twilightforest.block.enums.MazestoneVariant;
 
-public class EntityTFMazeSlime extends EntitySlime {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFMazeSlime extends EntitySlime implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/maze_slime");
 	private static final AttributeModifier DOUBLE_HEALTH = new AttributeModifier("Maze slime double health", 1, 1).setSaved(false);
 
@@ -109,4 +113,16 @@ public class EntityTFMazeSlime extends EntitySlime {
 		return LOOT_TABLE;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFMinotaur.java
+++ b/src/main/java/twilightforest/entity/EntityTFMinotaur.java
@@ -20,6 +20,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -29,7 +30,10 @@ import net.minecraft.world.World;
 import twilightforest.TwilightForestMod;
 import twilightforest.entity.ai.EntityAITFChargeAttack;
 
-public class EntityTFMinotaur extends EntityMob implements ITFCharger {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFMinotaur extends EntityMob implements ITFCharger, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/minotaur");
 	private static final DataParameter<Boolean> CHARGING = EntityDataManager.createKey(EntityTFMinotaur.class, DataSerializers.BOOLEAN);
 
@@ -130,4 +134,16 @@ public class EntityTFMinotaur extends EntityMob implements ITFCharger {
 		return LOOT_TABLE;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFMistWolf.java
+++ b/src/main/java/twilightforest/entity/EntityTFMistWolf.java
@@ -6,9 +6,13 @@ import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.init.MobEffects;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.world.World;
 
-public class EntityTFMistWolf extends EntityTFHostileWolf {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFMistWolf extends EntityTFHostileWolf implements ISavedCombatEntriesOnDeath {
 
 	public EntityTFMistWolf(World world) {
 		super(world);
@@ -57,5 +61,18 @@ public class EntityTFMistWolf extends EntityTFHostileWolf {
 	@Override
 	protected float getSoundPitch() {
 		return (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F + 0.6F;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFMosquitoSwarm.java
+++ b/src/main/java/twilightforest/entity/EntityTFMosquitoSwarm.java
@@ -12,13 +12,17 @@ import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.MobEffects;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import twilightforest.TFSounds;
 import twilightforest.biomes.TFBiomes;
 
-public class EntityTFMosquitoSwarm extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFMosquitoSwarm extends EntityMob implements ISavedCombatEntriesOnDeath {
 
 	public EntityTFMosquitoSwarm(World par1World) {
 		super(par1World);
@@ -89,5 +93,18 @@ public class EntityTFMosquitoSwarm extends EntityMob {
 	@Override
 	public int getMaxSpawnedInChunk() {
 		return 1;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFPinchBeetle.java
+++ b/src/main/java/twilightforest/entity/EntityTFPinchBeetle.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.ai.EntityAIWatchClosest;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -20,7 +21,10 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import twilightforest.entity.ai.EntityAITFChargeAttack;
 
-public class EntityTFPinchBeetle extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFPinchBeetle extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public EntityTFPinchBeetle(World world) {
 		super(world);
 		setSize(1.2F, 1.1F);
@@ -130,5 +134,18 @@ public class EntityTFPinchBeetle extends EntityMob {
 	@Override
 	public boolean canRiderInteract() {
 		return true;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFRedcap.java
+++ b/src/main/java/twilightforest/entity/EntityTFRedcap.java
@@ -19,6 +19,7 @@ import net.minecraft.init.Items;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -32,7 +33,10 @@ import twilightforest.entity.ai.EntityAITFRedcapLightTNT;
 import twilightforest.entity.ai.EntityAITFRedcapShy;
 import twilightforest.util.PlayerHelper;
 
-public class EntityTFRedcap extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFRedcap extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/redcap");
 
 	public ItemStack heldPick = new ItemStack(Items.IRON_PICKAXE, 1);
@@ -133,4 +137,16 @@ public class EntityTFRedcap extends EntityMob {
 		}
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFRedcapSapper.java
+++ b/src/main/java/twilightforest/entity/EntityTFRedcapSapper.java
@@ -5,6 +5,7 @@ import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -16,7 +17,10 @@ import twilightforest.entity.ai.EntityAITFRedcapPlantTNT;
 import twilightforest.item.TFItems;
 import twilightforest.util.PlayerHelper;
 
-public class EntityTFRedcapSapper extends EntityTFRedcap {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFRedcapSapper extends EntityTFRedcap implements ISavedCombatEntriesOnDeath {
 
 	public EntityTFRedcapSapper(World world) {
 		super(world);
@@ -55,5 +59,18 @@ public class EntityTFRedcapSapper extends EntityTFRedcap {
 				PlayerHelper.grantCriterion((EntityPlayerMP) source.getTrueSource(), new ResourceLocation(TwilightForestMod.ID, "hill2"), "redcap_sapper");
 			}
 		}
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFRovingCube.java
+++ b/src/main/java/twilightforest/entity/EntityTFRovingCube.java
@@ -2,13 +2,17 @@ package twilightforest.entity;
 
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.world.World;
 import twilightforest.TwilightForestMod;
 import twilightforest.client.particle.TFParticleType;
 import twilightforest.entity.ai.EntityAICubeCenterOnSymbol;
 import twilightforest.entity.ai.EntityAICubeMoveToRedstoneSymbols;
 
-public class EntityTFRovingCube extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFRovingCube extends EntityMob implements ISavedCombatEntriesOnDeath {
 
 	// data needed for cube AI
 
@@ -55,5 +59,16 @@ public class EntityTFRovingCube extends EntityMob {
 
 	}
 
+	private ArrayList<CombatEntry> combatList;
 
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFSkeletonDruid.java
+++ b/src/main/java/twilightforest/entity/EntityTFSkeletonDruid.java
@@ -7,6 +7,7 @@ import net.minecraft.init.Items;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -15,7 +16,10 @@ import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import twilightforest.TwilightForestMod;
 
-public class EntityTFSkeletonDruid extends EntitySkeleton {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFSkeletonDruid extends EntitySkeleton implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/skeleton_druid");
 
 	public EntityTFSkeletonDruid(World world) {
@@ -89,5 +93,18 @@ public class EntityTFSkeletonDruid extends EntitySkeleton {
 
 			return i <= this.rand.nextInt(12); // TF - rand(8) -> rand(12)
 		}
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFSlimeBeetle.java
+++ b/src/main/java/twilightforest/entity/EntityTFSlimeBeetle.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.SoundEvents;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -25,7 +26,10 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import twilightforest.TwilightForestMod;
 
-public class EntityTFSlimeBeetle extends EntityMob implements IRangedAttackMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFSlimeBeetle extends EntityMob implements IRangedAttackMob, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/slime_beetle");
 
 	public EntityTFSlimeBeetle(World world) {
@@ -97,4 +101,17 @@ public class EntityTFSlimeBeetle extends EntityMob implements IRangedAttackMob {
 
 	@Override
 	public void setSwingingArms(boolean swingingArms) {}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFSnowGuardian.java
+++ b/src/main/java/twilightforest/entity/EntityTFSnowGuardian.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -24,7 +25,10 @@ import twilightforest.TwilightForestMod;
 import twilightforest.client.particle.TFParticleType;
 import twilightforest.item.TFItems;
 
-public class EntityTFSnowGuardian extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFSnowGuardian extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/snow_guardian");
 
 	public EntityTFSnowGuardian(World par1World) {
@@ -173,5 +177,18 @@ public class EntityTFSnowGuardian extends EntityMob {
 	@Override
 	public int getMaxSpawnedInChunk() {
 		return 8;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFSwarmSpider.java
+++ b/src/main/java/twilightforest/entity/EntityTFSwarmSpider.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.monster.EntitySpider;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -17,8 +18,11 @@ import twilightforest.TFFeature;
 import twilightforest.TwilightForestMod;
 import twilightforest.util.PlayerHelper;
 
+import java.util.ArrayList;
+import java.util.List;
 
-public class EntityTFSwarmSpider extends EntitySpider {
+
+public class EntityTFSwarmSpider extends EntitySpider implements ISavedCombatEntriesOnDeath {
 
 	protected boolean shouldSpawn = false;
 
@@ -163,4 +167,16 @@ public class EntityTFSwarmSpider extends EntitySpider {
 		return 16;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFTowerBroodling.java
+++ b/src/main/java/twilightforest/entity/EntityTFTowerBroodling.java
@@ -1,9 +1,13 @@
 package twilightforest.entity;
 
 import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.world.World;
 
-public class EntityTFTowerBroodling extends EntityTFSwarmSpider {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFTowerBroodling extends EntityTFSwarmSpider implements ISavedCombatEntriesOnDeath {
 	public EntityTFTowerBroodling(World world) {
 		this(world, true);
 	}
@@ -36,5 +40,18 @@ public class EntityTFTowerBroodling extends EntityTFSwarmSpider {
 		another.spawnExplosionParticle();
 
 		return true;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFTowerGhast.java
+++ b/src/main/java/twilightforest/entity/EntityTFTowerGhast.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.projectile.EntityLargeFireball;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -20,9 +21,11 @@ import twilightforest.TFFeature;
 import twilightforest.entity.ai.EntityAITFFindEntityNearestPlayer;
 import twilightforest.entity.boss.EntityTFUrGhast;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
-public class EntityTFTowerGhast extends EntityGhast {
+public class EntityTFTowerGhast extends EntityGhast implements ISavedCombatEntriesOnDeath {
 	// 0 = idle, 1 = eyes open / tracking player, 2 = shooting fireball
 	private static final DataParameter<Byte> ATTACK_STATUS = EntityDataManager.createKey(EntityTFTowerGhast.class, DataSerializers.BYTE);
 	private static final DataParameter<Byte> ATTACK_TIMER = EntityDataManager.createKey(EntityTFTowerGhast.class, DataSerializers.BYTE);
@@ -377,5 +380,18 @@ public class EntityTFTowerGhast extends EntityGhast {
 		return this.maximumHomeDistance != -1.0F;
 	}
 	// End copy
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }
 

--- a/src/main/java/twilightforest/entity/EntityTFTowerGolem.java
+++ b/src/main/java/twilightforest/entity/EntityTFTowerGolem.java
@@ -15,10 +15,7 @@ import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.pathfinding.PathNodeType;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
@@ -26,7 +23,10 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import twilightforest.TwilightForestMod;
 
-public class EntityTFTowerGolem extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFTowerGolem extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/tower_golem");
 	private int attackTimer;
 
@@ -134,4 +134,16 @@ public class EntityTFTowerGolem extends EntityMob {
 		return 16;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFTowerTermite.java
+++ b/src/main/java/twilightforest/entity/EntityTFTowerTermite.java
@@ -15,11 +15,7 @@ import net.minecraft.entity.ai.EntityAIWatchClosest;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EntityDamageSource;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import twilightforest.TwilightForestMod;
@@ -27,9 +23,11 @@ import twilightforest.block.BlockTFTowerWood;
 import twilightforest.block.TFBlocks;
 import twilightforest.block.enums.TowerWoodVariant;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
-public class EntityTFTowerTermite extends EntityMob {
+public class EntityTFTowerTermite extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/tower_termite");
 	private AISummonSilverfish summonSilverfish;
 
@@ -244,4 +242,16 @@ public class EntityTFTowerTermite extends EntityMob {
 		}
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFTroll.java
+++ b/src/main/java/twilightforest/entity/EntityTFTroll.java
@@ -23,6 +23,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -34,7 +35,10 @@ import twilightforest.block.TFBlocks;
 import twilightforest.entity.boss.EntityTFIceBomb;
 import twilightforest.util.WorldUtil;
 
-public class EntityTFTroll extends EntityMob implements IRangedAttackMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFTroll extends EntityMob implements IRangedAttackMob, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/troll");
 	private static final DataParameter<Boolean> ROCK_FLAG = EntityDataManager.createKey(EntityTFTroll.class, DataSerializers.BOOLEAN);
 	private static final AttributeModifier ROCK_MODIFIER = new AttributeModifier("Rock follow boost", 24, 0).setSaved(false);
@@ -213,5 +217,18 @@ public class EntityTFTroll extends EntityMob implements IRangedAttackMob {
 		}
 
 		this.swingProgress = (float) this.swingProgressInt / (float) i;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFWinterWolf.java
+++ b/src/main/java/twilightforest/entity/EntityTFWinterWolf.java
@@ -13,6 +13,7 @@ import net.minecraft.item.EnumDyeColor;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -23,7 +24,10 @@ import twilightforest.biomes.TFBiomes;
 import twilightforest.client.particle.TFParticleType;
 import twilightforest.entity.ai.EntityAITFBreathAttack;
 
-public class EntityTFWinterWolf extends EntityTFHostileWolf implements IBreathAttacker {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFWinterWolf extends EntityTFHostileWolf implements IBreathAttacker, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/winter_wolf");
 	private static final DataParameter<Boolean> BREATH_FLAG = EntityDataManager.createKey(EntityTFWinterWolf.class, DataSerializers.BOOLEAN);
 	private static final float BREATH_DAMAGE = 2.0F;
@@ -128,6 +132,19 @@ public class EntityTFWinterWolf extends EntityTFHostileWolf implements IBreathAt
 	@Override
 	public ResourceLocation getLootTable() {
 		return LOOT_TABLE;
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 
 }

--- a/src/main/java/twilightforest/entity/EntityTFWraith.java
+++ b/src/main/java/twilightforest/entity/EntityTFWraith.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemAxe;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -27,9 +28,11 @@ import twilightforest.TFSounds;
 import twilightforest.TwilightForestMod;
 import twilightforest.util.PlayerHelper;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
-public class EntityTFWraith extends EntityFlying implements IMob {
+public class EntityTFWraith extends EntityFlying implements IMob, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/wraith");
 
 	public EntityTFWraith(World world) {
@@ -321,5 +324,18 @@ public class EntityTFWraith extends EntityFlying implements IMob {
 	@Override
 	public boolean getCanSpawnHere() {
 		return this.world.getDifficulty() != EnumDifficulty.PEACEFUL && this.isValidLightLevel() && super.getCanSpawnHere();
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/EntityTFYeti.java
+++ b/src/main/java/twilightforest/entity/EntityTFYeti.java
@@ -15,6 +15,7 @@ import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.pathfinding.PathNodeType;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -25,8 +26,10 @@ import twilightforest.biomes.TFBiomes;
 import twilightforest.entity.ai.EntityAITFThrowRider;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
-public class EntityTFYeti extends EntityMob {
+public class EntityTFYeti extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/yeti");
 	private static final DataParameter<Boolean> ANGER_FLAG = EntityDataManager.createKey(EntityTFYeti.class, DataSerializers.BOOLEAN);
 	private static final AttributeModifier ANGRY_MODIFIER = new AttributeModifier("Angry follow range boost", 24, 0).setSaved(false);
@@ -182,4 +185,16 @@ public class EntityTFYeti extends EntityMob {
 		return LOOT_TABLE;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/ISavedCombatEntriesOnDeath.java
+++ b/src/main/java/twilightforest/entity/ISavedCombatEntriesOnDeath.java
@@ -1,0 +1,9 @@
+package twilightforest.entity;
+
+import net.minecraft.util.CombatEntry;
+
+import java.util.List;
+
+public interface ISavedCombatEntriesOnDeath {
+    List<CombatEntry> getCombatList();
+}

--- a/src/main/java/twilightforest/entity/boss/EntityTFHydra.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFHydra.java
@@ -17,10 +17,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -35,6 +32,7 @@ import twilightforest.TwilightForestMod;
 import twilightforest.block.BlockTFBossSpawner;
 import twilightforest.block.TFBlocks;
 import twilightforest.block.enums.BossVariant;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 import twilightforest.util.WorldUtil;
 import twilightforest.world.ChunkGeneratorTwilightForest;
 import twilightforest.world.TFWorld;
@@ -45,7 +43,7 @@ import java.util.Comparator;
 import java.util.List;
 
 
-public class EntityTFHydra extends EntityLiving implements IEntityMultiPart, IMob {
+public class EntityTFHydra extends EntityLiving implements IEntityMultiPart, IMob, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/hydra");
 	private static final int TICKS_BEFORE_HEALING = 1000;
 	private static final int HEAD_RESPAWN_TICKS = 100;
@@ -802,4 +800,16 @@ public class EntityTFHydra extends EntityLiving implements IEntityMultiPart, IMo
 		return this.world;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFIceCrystal.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFIceCrystal.java
@@ -10,14 +10,19 @@ import net.minecraft.entity.ai.EntityAIWander;
 import net.minecraft.entity.ai.EntityAIWatchClosest;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import twilightforest.TFSounds;
 import twilightforest.TwilightForestMod;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 
-public class EntityTFIceCrystal extends EntityMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFIceCrystal extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/ice_crystal");
 	private int crystalAge;
 	private int maxCrystalAge = -1;
@@ -87,5 +92,18 @@ public class EntityTFIceCrystal extends EntityMob {
 				this.setDead();
 			}
 		}
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFKnightPhantom.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFKnightPhantom.java
@@ -21,6 +21,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.SoundEvent;
@@ -36,6 +37,7 @@ import twilightforest.TFTreasure;
 import twilightforest.block.BlockTFBossSpawner;
 import twilightforest.block.TFBlocks;
 import twilightforest.block.enums.BossVariant;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 import twilightforest.entity.NoClipMoveHelper;
 import twilightforest.entity.ai.EntityAIPhantomAttackStart;
 import twilightforest.entity.ai.EntityAIPhantomThrowWeapon;
@@ -47,10 +49,11 @@ import twilightforest.world.ChunkGeneratorTwilightForest;
 import twilightforest.world.TFWorld;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class EntityTFKnightPhantom extends EntityFlying implements IMob {
+public class EntityTFKnightPhantom extends EntityFlying implements IMob, ISavedCombatEntriesOnDeath {
 	private static final DataParameter<Boolean> FLAG_CHARGING = EntityDataManager.createKey(EntityTFKnightPhantom.class, DataSerializers.BOOLEAN);
 	private static final AttributeModifier CHARGING_MODIFIER = new AttributeModifier("Charging attack boost", 7, 0).setSaved(false);
 	private int number;
@@ -515,4 +518,17 @@ public class EntityTFKnightPhantom extends EntityFlying implements IMob {
 		return this.maximumHomeDistance != -1.0F;
 	}
 	// End copy
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFLich.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFLich.java
@@ -16,10 +16,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
@@ -30,15 +27,17 @@ import net.minecraft.world.World;
 import twilightforest.TFFeature;
 import twilightforest.TwilightForestMod;
 import twilightforest.entity.EntityTFSwarmSpider;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 import twilightforest.entity.ai.EntityAITFLichMinions;
 import twilightforest.entity.ai.EntityAITFLichShadows;
 import twilightforest.world.ChunkGeneratorTwilightForest;
 import twilightforest.world.TFWorld;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public class EntityTFLich extends EntityMob {
+public class EntityTFLich extends EntityMob implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/lich");
 	private static final Set<Class<? extends Entity>> POPPABLE = ImmutableSet.of(EntitySkeleton.class, EntityZombie.class, EntityEnderman.class, EntitySpider.class, EntityCreeper.class, EntityTFSwarmSpider.class);
 	private static final DataParameter<Boolean> DATA_ISCLONE = EntityDataManager.createKey(EntityTFLich.class, DataSerializers.BOOLEAN);
@@ -592,4 +591,16 @@ public class EntityTFLich extends EntityMob {
 		return EnumCreatureAttribute.UNDEAD;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFLichMinion.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFLichMinion.java
@@ -4,14 +4,17 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.init.MobEffects;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.world.World;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 
+import java.util.ArrayList;
 import java.util.List;
 
 
-public class EntityTFLichMinion extends EntityZombie {
+public class EntityTFLichMinion extends EntityZombie implements ISavedCombatEntriesOnDeath {
 	EntityTFLich master;
 
 	public EntityTFLichMinion(World par1World) {
@@ -70,5 +73,18 @@ public class EntityTFLichMinion extends EntityZombie {
 				break;
 			}
 		}
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFMinoshroom.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFMinoshroom.java
@@ -4,14 +4,19 @@ import net.minecraft.entity.IEntityLivingData;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.World;
 import twilightforest.TwilightForestMod;
 import twilightforest.entity.EntityTFMinotaur;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 import twilightforest.item.TFItems;
 
-public class EntityTFMinoshroom extends EntityTFMinotaur {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFMinoshroom extends EntityTFMinotaur implements ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/minoshroom");
 
 	public EntityTFMinoshroom(World par1World) {
@@ -44,4 +49,16 @@ public class EntityTFMinoshroom extends EntityTFMinotaur {
 		return false;
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFNaga.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFNaga.java
@@ -1,29 +1,14 @@
 package twilightforest.entity.boss;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityList;
-import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.IEntityMultiPart;
-import net.minecraft.entity.SharedMonsterAttributes;
-import net.minecraft.entity.ai.EntityAIBase;
-import net.minecraft.entity.ai.EntityAIHurtByTarget;
-import net.minecraft.entity.ai.EntityAINearestAttackableTarget;
-import net.minecraft.entity.ai.EntityAISwimming;
-import net.minecraft.entity.ai.EntityAIWander;
-import net.minecraft.entity.ai.EntityMoveHelper;
-import net.minecraft.entity.ai.RandomPositionGenerator;
+import net.minecraft.entity.*;
+import net.minecraft.entity.ai.*;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
-import net.minecraft.entity.MultiPartEntityPart;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagIntArray;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -34,17 +19,20 @@ import net.minecraft.world.BossInfoServer;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants;
-import org.apache.http.cookie.SM;
 import twilightforest.TFFeature;
 import twilightforest.TFSounds;
 import twilightforest.TwilightForestMod;
 import twilightforest.block.BlockTFBossSpawner;
 import twilightforest.block.TFBlocks;
 import twilightforest.block.enums.BossVariant;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 import twilightforest.world.ChunkGeneratorTwilightForest;
 import twilightforest.world.TFWorld;
 
-public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFNaga extends EntityMob implements IEntityMultiPart, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/naga");
 	private static final int TICKS_BEFORE_HEALING = 600;
 	private static final int MAX_SEGMENTS = 12;
@@ -781,5 +769,18 @@ public class EntityTFNaga extends EntityMob implements IEntityMultiPart {
 	public void removeTrackingPlayer(EntityPlayerMP player) {
 		super.removeTrackingPlayer(player);
 		this.bossInfo.removePlayer(player);
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFSnowQueen.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFSnowQueen.java
@@ -20,10 +20,7 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -34,6 +31,7 @@ import twilightforest.TFSounds;
 import twilightforest.TwilightForestMod;
 import twilightforest.client.particle.TFParticleType;
 import twilightforest.entity.IBreathAttacker;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 import twilightforest.entity.ai.EntityAITFHoverBeam;
 import twilightforest.entity.ai.EntityAITFHoverSummon;
 import twilightforest.entity.ai.EntityAITFHoverThenDrop;
@@ -41,9 +39,10 @@ import twilightforest.util.WorldUtil;
 import twilightforest.world.ChunkGeneratorTwilightForest;
 import twilightforest.world.TFWorld;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public class EntityTFSnowQueen extends EntityMob implements IEntityMultiPart, IBreathAttacker {
+public class EntityTFSnowQueen extends EntityMob implements IEntityMultiPart, IBreathAttacker, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/snow_queen");
 	private static final int MAX_SUMMONS = 6;
 	private static final DataParameter<Boolean> BEAM_FLAG = EntityDataManager.createKey(EntityTFSnowQueen.class, DataSerializers.BOOLEAN);
@@ -420,5 +419,18 @@ public class EntityTFSnowQueen extends EntityMob implements IEntityMultiPart, IB
 	public void doBreathAttack(Entity target) {
 		target.attackEntityFrom(DamageSource.causeMobDamage(this), BREATH_DAMAGE);
 		// TODO: slow target?
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFUrGhast.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFUrGhast.java
@@ -2,7 +2,6 @@ package twilightforest.entity.boss;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityList;
-import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.EntityAIBase;
@@ -14,11 +13,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.BossInfo;
@@ -34,6 +33,7 @@ import twilightforest.block.enums.TowerDeviceVariant;
 import twilightforest.client.particle.TFParticleType;
 import twilightforest.entity.EntityTFMiniGhast;
 import twilightforest.entity.EntityTFTowerGhast;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 import twilightforest.entity.NoClipMoveHelper;
 import twilightforest.world.ChunkGeneratorTwilightForest;
 import twilightforest.world.TFWorld;
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class EntityTFUrGhast extends EntityTFTowerGhast {
+public class EntityTFUrGhast extends EntityTFTowerGhast implements ISavedCombatEntriesOnDeath {
 
 	private static final DataParameter<Boolean> DATA_TANTRUM = EntityDataManager.createKey(EntityTFUrGhast.class, DataSerializers.BOOLEAN);
 
@@ -583,5 +583,18 @@ public class EntityTFUrGhast extends EntityTFTowerGhast {
 	@Override
 	protected boolean shouldAttack(EntityLivingBase living) {
 		return !this.isInTantrum();
+	}
+
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
 	}
 }

--- a/src/main/java/twilightforest/entity/boss/EntityTFYetiAlpha.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFYetiAlpha.java
@@ -24,6 +24,7 @@ import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.pathfinding.PathNodeType;
+import net.minecraft.util.CombatEntry;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
@@ -38,6 +39,7 @@ import net.minecraft.world.World;
 import twilightforest.TFFeature;
 import twilightforest.TwilightForestMod;
 import twilightforest.client.particle.TFParticleType;
+import twilightforest.entity.ISavedCombatEntriesOnDeath;
 import twilightforest.entity.ai.EntityAIStayNearHome;
 import twilightforest.entity.ai.EntityAITFThrowRider;
 import twilightforest.entity.ai.EntityAITFYetiRampage;
@@ -46,7 +48,10 @@ import twilightforest.util.WorldUtil;
 import twilightforest.world.ChunkGeneratorTwilightForest;
 import twilightforest.world.TFWorld;
 
-public class EntityTFYetiAlpha extends EntityMob implements IRangedAttackMob {
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntityTFYetiAlpha extends EntityMob implements IRangedAttackMob, ISavedCombatEntriesOnDeath {
 	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/yeti_alpha");
 	private static final DataParameter<Byte> RAMPAGE_FLAG = EntityDataManager.createKey(EntityTFYetiAlpha.class, DataSerializers.BYTE);
 	private static final DataParameter<Byte> TIRED_FLAG = EntityDataManager.createKey(EntityTFYetiAlpha.class, DataSerializers.BYTE);
@@ -385,4 +390,16 @@ public class EntityTFYetiAlpha extends EntityMob implements IRangedAttackMob {
 		}
 	}
 
+	private ArrayList<CombatEntry> combatList;
+
+	@Override
+	public void sendEndCombat() {
+		super.sendEndCombat();
+		combatList = new ArrayList<>(this.getCombatTracker().combatEntries);
+	}
+
+	@Override
+	public List<CombatEntry> getCombatList() {
+		return combatList;
+	}
 }

--- a/src/main/resources/META-INF/tf_at.cfg
+++ b/src/main/resources/META-INF/tf_at.cfg
@@ -49,3 +49,6 @@ public net.minecraft.client.multiplayer.ClientAdvancementManager field_192803_d 
 
 # Advancements
 public net.minecraft.advancements.CriteriaTriggers func_192118_a(Lnet/minecraft/advancements/ICriterionTrigger;)Lnet/minecraft/advancements/ICriterionTrigger; #register
+
+# CombatTracker
+public net.minecraft.util.CombatTracker field_94556_a # combatEntries

--- a/src/main/resources/assets/twilightforest/advancements/progress_hydra.json
+++ b/src/main/resources/assets/twilightforest/advancements/progress_hydra.json
@@ -15,11 +15,13 @@
   "parent": "twilightforest:progress_labyrinth",
   "criteria": {
     "hydra": {
-      "trigger": "minecraft:player_killed_entity",
+      "trigger": "twilightforest:player_group_killed_entity",
       "conditions": {
-        "entity": {
+        "entity_killed": {
           "type": "twilightforest:hydra"
-        }
+        },
+        "damage_threshold_denominator": 2,
+        "comparator": "OR"
       }
     },
     "stroganoff": {

--- a/src/main/resources/assets/twilightforest/advancements/progress_knights.json
+++ b/src/main/resources/assets/twilightforest/advancements/progress_knights.json
@@ -14,11 +14,13 @@
   "parent": "twilightforest:progress_trophy_pedestal",
   "criteria": {
     "knight": {
-      "trigger": "minecraft:player_killed_entity",
+      "trigger": "twilightforest:player_group_killed_entity",
       "conditions": {
-        "entity": {
+        "entity_killed": {
           "type": "twilightforest:knight_phantom"
-        }
+        },
+        "damage_threshold_denominator": 2,
+        "comparator": "OR"
       }
     },
     "previous_progression": {

--- a/src/main/resources/assets/twilightforest/advancements/progress_lich.json
+++ b/src/main/resources/assets/twilightforest/advancements/progress_lich.json
@@ -15,11 +15,13 @@
   "parent": "twilightforest:progress_naga",
   "criteria": {
     "kill_lich": {
-      "trigger": "minecraft:player_killed_entity",
+      "trigger": "twilightforest:player_group_killed_entity",
       "conditions": {
-        "entity": {
+        "entity_killed": {
           "type": "twilightforest:lich"
-        }
+        },
+        "damage_threshold_denominator": 2,
+        "comparator": "OR"
       }
     },
     "kill_naga": {

--- a/src/main/resources/assets/twilightforest/advancements/progress_naga.json
+++ b/src/main/resources/assets/twilightforest/advancements/progress_naga.json
@@ -15,21 +15,21 @@
   "parent": "twilightforest:twilight_hunter",
   "criteria": {
     "naga": {
-      "trigger": "minecraft:player_killed_entity",
+      "trigger": "twilightforest:player_group_killed_entity",
       "conditions": {
-        "entity": {
+        "entity_killed": {
           "type": "twilightforest:naga"
-        }
+        },
+        "damage_threshold_denominator": 2,
+        "comparator": "OR"
       }
     },
     "scale": {
       "trigger": "minecraft:inventory_changed",
       "conditions": {
-        "items": [
-          {
+        "items": [{
             "item": "twilightforest:naga_scale"
-          }
-        ]
+        }]
       }
     },
     "kill_mob": {

--- a/src/main/resources/assets/twilightforest/advancements/progress_ur_ghast.json
+++ b/src/main/resources/assets/twilightforest/advancements/progress_ur_ghast.json
@@ -15,11 +15,13 @@
   "parent": "twilightforest:progress_knights",
   "criteria": {
     "ghast": {
-      "trigger": "minecraft:player_killed_entity",
+      "trigger": "twilightforest:player_group_killed_entity",
       "conditions": {
-        "entity": {
+        "entity_killed": {
           "type": "twilightforest:ur_ghast"
-        }
+        },
+        "damage_threshold_denominator": 2,
+        "comparator": "OR"
       }
     },
     "previous_progression": {

--- a/src/main/resources/assets/twilightforest/advancements/progress_yeti.json
+++ b/src/main/resources/assets/twilightforest/advancements/progress_yeti.json
@@ -14,11 +14,13 @@
   "parent": "twilightforest:progress_ur_ghast",
   "criteria": {
     "yeti": {
-      "trigger": "minecraft:player_killed_entity",
+      "trigger": "twilightforest:player_group_killed_entity",
       "conditions": {
-        "entity": {
+        "entity_killed": {
           "type": "twilightforest:yeti_alpha"
-        }
+        },
+        "damage_threshold_denominator": 2,
+        "comparator": "OR"
       }
     },
     "previous_progression": {


### PR DESCRIPTION
This PR is a fix for #164 but I'm not really sure about the last part, which involves me adding `ISavedCombatEntriesOnDeath` since the combat entries in the tracker get wiped every time the mob dies before the death event actually fires.