### PR TITLE
Fixed TFPortal can't be crated

### DIFF
--- a/src/main/java/twilightforest/block/BlockTFPortal.java
+++ b/src/main/java/twilightforest/block/BlockTFPortal.java
@@ -131,7 +131,7 @@ public class BlockTFPortal extends BlockBreakable {
 
 	private static boolean isNatureBlock(IBlockState state) {
 		Material mat = state.getMaterial();
-		return state.isFullCube() && (mat == Material.PLANTS || mat == Material.VINE || mat == Material.LEAVES);
+		return mat == Material.PLANTS || mat == Material.VINE || mat == Material.LEAVES;
 	}
 
 	private static boolean isGrassOrDirt(IBlockState state) {


### PR DESCRIPTION
Modified method isNatureBlock.
Nature blocks are not full cube.
Fixed TFPortal can't be crated because method isNatureBlock always return false.