### PR TITLE
Update BlockTFPortal.java

### DIFF
--- a/src/main/java/twilightforest/block/BlockTFPortal.java
+++ b/src/main/java/twilightforest/block/BlockTFPortal.java
@@ -72,7 +72,7 @@ public class BlockTFPortal extends BlockBreakable {
 
 			if (recursivelyValidatePortal(world, pos, blocksChecked, number) && number.getNumber() > 3) {
 				activationItem.getItem().shrink(1);
-				world.addWeatherEffect(new EntityLightningBolt(world, pos.getX(), pos.getY(), pos.getZ(), false));
+				world.addWeatherEffect(new EntityLightningBolt(world, pos.getX(), pos.getY(), pos.getZ(), true));
 
 				for (Map.Entry<BlockPos, Boolean> checkedPos : blocksChecked.entrySet())
 					if (checkedPos.getValue()) world.setBlockState(checkedPos.getKey(), TFBlocks.portal.getDefaultState(), 2);


### PR DESCRIPTION
Lightning bolt always make the blocks near by portal burn or kill the players. So use a effect of lightning bolt instead of a real one.