### PR TITLE
Drop existing items instead of overwriting them with kept items on respawn

### DIFF
--- a/src/main/java/twilightforest/TFEventListener.java
+++ b/src/main/java/twilightforest/TFEventListener.java
@@ -266,6 +266,7 @@ public class TFEventListener {
 
 			if (tier1) {
 				keepAllArmor(player, keepInventory);
+				keepOffHand(player, keepInventory);
 				if (!tier2 && !player.inventory.getCurrentItem().isEmpty()) {
 					keepInventory.mainInventory.set(player.inventory.currentItem, player.inventory.mainInventory.get(player.inventory.currentItem).copy());
 					player.inventory.mainInventory.set(player.inventory.currentItem, ItemStack.EMPTY);
@@ -307,6 +308,13 @@ public class TFEventListener {
 		}
 	}
 
+	private static void keepOffHand(EntityPlayer player, InventoryPlayer keepInventory) {
+		for (int i = 0; i < player.inventory.offHandInventory.size(); i++) {
+			keepInventory.offHandInventory.set(i, player.inventory.offHandInventory.get(i).copy());
+			player.inventory.offHandInventory.set(i, ItemStack.EMPTY);
+		}
+	}
+
 	/**
 	 * Maybe we kept some stuff for the player!
 	 */
@@ -320,6 +328,11 @@ public class TFEventListener {
 			for (int i = 0; i < player.inventory.armorInventory.size(); i++) {
 				if (!keepInventory.armorInventory.get(i).isEmpty()) {
 					player.inventory.armorInventory.set(i, keepInventory.armorInventory.get(i));
+				}
+			}
+			for (int i = 0; i < player.inventory.offHandInventory.size(); i++) {
+				if (!keepInventory.offHandInventory.get(i).isEmpty()) {
+					player.inventory.offHandInventory.set(i, keepInventory.offHandInventory.get(i));
 				}
 			}
 			for (int i = 0; i < player.inventory.mainInventory.size(); i++) {

--- a/src/main/java/twilightforest/TFEventListener.java
+++ b/src/main/java/twilightforest/TFEventListener.java
@@ -326,18 +326,30 @@ public class TFEventListener {
 			TwilightForestMod.LOGGER.debug("Player {} respawned and received items held in storage", player.getName());
 
 			for (int i = 0; i < player.inventory.armorInventory.size(); i++) {
-				if (!keepInventory.armorInventory.get(i).isEmpty()) {
-					player.inventory.armorInventory.set(i, keepInventory.armorInventory.get(i));
+				ItemStack kept = keepInventory.armorInventory.get(i);
+				if (!kept.isEmpty()) {
+					ItemStack existing = player.inventory.armorInventory.set(i, kept);
+					if (!existing.isEmpty()) {
+						player.dropItem(existing, false);
+					}
 				}
 			}
 			for (int i = 0; i < player.inventory.offHandInventory.size(); i++) {
-				if (!keepInventory.offHandInventory.get(i).isEmpty()) {
-					player.inventory.offHandInventory.set(i, keepInventory.offHandInventory.get(i));
+				ItemStack kept = keepInventory.offHandInventory.get(i);
+				if (!kept.isEmpty()) {
+					ItemStack existing = player.inventory.offHandInventory.set(i, kept);
+					if (!existing.isEmpty()) {
+						player.dropItem(existing, false);
+					}
 				}
 			}
 			for (int i = 0; i < player.inventory.mainInventory.size(); i++) {
-				if (!keepInventory.mainInventory.get(i).isEmpty()) {
-					player.inventory.mainInventory.set(i, keepInventory.mainInventory.get(i));
+				ItemStack kept = keepInventory.mainInventory.get(i);
+				if (!kept.isEmpty()) {
+					ItemStack existing = player.inventory.mainInventory.set(i, kept);
+					if (!existing.isEmpty()) {
+						player.dropItem(existing, false);
+					}
 				}
 			}
 


### PR DESCRIPTION
This changes the `PlayerRespawnEvent` handler to drop any items that would be overwritten by a saved item from the Charm of Keeping, preventing item loss in the event that anything is put into the player's inventory before.
As the items from the charm are the items the player was holding before they died, I think it's better to keep them in the "right" place and drop the other item, rather than the other way around.

Otherwise, I think it would be needed to specify `HIGHEST` priority on the event handler to try to ensure that the inventory is empty, but that can't really be guaranteed to work.