### PR TITLE
Fix various missing getBlockFaceShape overrides

### DIFF
--- a/src/main/java/twilightforest/block/BlockTFCastleDoor.java
+++ b/src/main/java/twilightforest/block/BlockTFCastleDoor.java
@@ -5,6 +5,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.properties.PropertyInteger;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
@@ -88,6 +89,12 @@ public class BlockTFCastleDoor extends Block implements ModelRegisterCallback {
 	@Deprecated
 	public boolean isFullCube(IBlockState state) {
 		return !this.isVanished;
+	}
+
+	@Override
+	@Deprecated
+	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+		return isVanished ? BlockFaceShape.UNDEFINED : super.getBlockFaceShape(worldIn, state, pos, face);
 	}
 
 	@Override

--- a/src/main/java/twilightforest/block/BlockTFCritter.java
+++ b/src/main/java/twilightforest/block/BlockTFCritter.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockDirectional;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -91,6 +92,18 @@ public abstract class BlockTFCritter extends Block {
 	@Deprecated
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
+	}
+
+	@Override
+	@Deprecated
+	public boolean isFullCube(IBlockState state) {
+		return false;
+	}
+
+	@Override
+	@Deprecated
+	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+		return BlockFaceShape.UNDEFINED;
 	}
 
 	@Override

--- a/src/main/java/twilightforest/block/BlockTFExperiment115.java
+++ b/src/main/java/twilightforest/block/BlockTFExperiment115.java
@@ -8,6 +8,7 @@ import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.properties.PropertyInteger;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
@@ -82,6 +83,11 @@ public class BlockTFExperiment115 extends Block implements ModelRegisterCallback
     public boolean isOpaqueCube(IBlockState state)
     {
         return false;
+    }
+
+    @Override
+    public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+        return BlockFaceShape.UNDEFINED;
     }
 
     @Override

--- a/src/main/java/twilightforest/block/BlockTFFirefly.java
+++ b/src/main/java/twilightforest/block/BlockTFFirefly.java
@@ -1,15 +1,11 @@
 package twilightforest.block;
 
 import net.minecraft.block.BlockDirectional;
-import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.block.statemap.StateMap;
 import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.client.model.ModelLoader;
@@ -17,7 +13,6 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import twilightforest.TwilightForestMod;
 import twilightforest.client.ModelRegisterCallback;
-import twilightforest.tileentity.critters.TileEntityTFFirefly;
 import twilightforest.tileentity.critters.TileEntityTFFireflyTicking;
 
 import java.util.Random;
@@ -54,10 +49,5 @@ public class BlockTFFirefly extends BlockTFCritter implements ModelRegisterCallb
 		ModelLoader.setCustomStateMapper(this, new StateMap.Builder().ignore(BlockDirectional.FACING).build());
 		ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(this), 0, new ModelResourceLocation(getRegistryName(), "inventory"));
 		ForgeHooksClient.registerTESRItemStack(Item.getItemFromBlock(this), 0, TileEntityTFFireflyTicking.class);
-	}
-
-	@Override
-	public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
-		return BlockFaceShape.UNDEFINED;
 	}
 }

--- a/src/main/java/twilightforest/block/BlockTFFireflyJar.java
+++ b/src/main/java/twilightforest/block/BlockTFFireflyJar.java
@@ -3,8 +3,10 @@ package twilightforest.block;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
@@ -40,6 +42,12 @@ public class BlockTFFireflyJar extends Block implements ModelRegisterCallback {
 	@Deprecated
 	public boolean isFullCube(IBlockState state) {
 		return false;
+	}
+
+	@Override
+	@Deprecated
+	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+		return BlockFaceShape.UNDEFINED;
 	}
 
 	@Override

--- a/src/main/java/twilightforest/block/BlockTFPortal.java
+++ b/src/main/java/twilightforest/block/BlockTFPortal.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockBreakable;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -89,8 +90,15 @@ public class BlockTFPortal extends BlockBreakable {
 	}
 
 	@Override
-	public boolean isOpaqueCube(IBlockState state) {
+	@Deprecated
+	public boolean isFullCube(IBlockState state) {
 		return false;
+	}
+
+	@Override
+	@Deprecated
+	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+		return BlockFaceShape.UNDEFINED;
 	}
 
 	public boolean tryToCreatePortal(World world, BlockPos pos, EntityItem activationItem) {

--- a/src/main/java/twilightforest/block/BlockTFSlider.java
+++ b/src/main/java/twilightforest/block/BlockTFSlider.java
@@ -3,6 +3,7 @@ package twilightforest.block;
 import net.minecraft.block.BlockRotatedPillar;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyInteger;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.statemap.StateMap;
@@ -80,6 +81,18 @@ public class BlockTFSlider extends BlockRotatedPillar implements ModelRegisterCa
 	@Deprecated
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
+	}
+
+	@Override
+	@Deprecated
+	public boolean isFullCube(IBlockState state) {
+		return false;
+	}
+
+	@Override
+	@Deprecated
+	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+		return BlockFaceShape.UNDEFINED;
 	}
 
 	@Override

--- a/src/main/java/twilightforest/block/BlockTFSpiralBrick.java
+++ b/src/main/java/twilightforest/block/BlockTFSpiralBrick.java
@@ -5,6 +5,7 @@ import net.minecraft.block.SoundType;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.statemap.StateMap;
@@ -15,6 +16,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
@@ -146,6 +148,25 @@ public class BlockTFSpiralBrick extends Block implements ModelRegisterCallback {
     @Override
     public boolean isOpaqueCube(IBlockState state) {
         return false;
+    }
+
+    @Override
+    public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+
+        EnumFacing.Axis axis = state.getValue(AXIS_FACING);
+        if (face.getAxis() == axis) {
+            return BlockFaceShape.UNDEFINED;
+        }
+
+        EnumFacing top  = axis == EnumFacing.Axis.Y ? EnumFacing.NORTH : EnumFacing.UP;
+        EnumFacing left = axis == EnumFacing.Axis.X ? EnumFacing.SOUTH : EnumFacing.WEST;
+
+        Diagonals diagonal = state.getValue(DIAGONAL);
+        if (face == (diagonal.isLeft() ? left : left.getOpposite()) || face == (diagonal.isTop() ? top : top.getOpposite())) {
+            return BlockFaceShape.SOLID;
+        } else {
+            return BlockFaceShape.UNDEFINED;
+        }
     }
 
     @Override

--- a/src/main/java/twilightforest/block/BlockTFThornRose.java
+++ b/src/main/java/twilightforest/block/BlockTFThornRose.java
@@ -3,6 +3,7 @@ package twilightforest.block;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.Item;
@@ -41,6 +42,18 @@ public class BlockTFThornRose extends Block implements ModelRegisterCallback {
 	@Deprecated
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
+	}
+
+	@Override
+	@Deprecated
+	public boolean isFullCube(IBlockState state) {
+		return false;
+	}
+
+	@Override
+	@Deprecated
+	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+		return BlockFaceShape.UNDEFINED;
 	}
 
 	@Override

--- a/src/main/java/twilightforest/block/BlockTFTowerTranslucent.java
+++ b/src/main/java/twilightforest/block/BlockTFTowerTranslucent.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
@@ -106,6 +107,18 @@ public class BlockTFTowerTranslucent extends Block implements ModelRegisterCallb
 			return REAPPEARING_BB;
 		} else {
 			return FULL_BLOCK_AABB;
+		}
+	}
+
+	@Override
+	@Deprecated
+	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+		TowerTranslucentVariant variant = state.getValue(VARIANT);
+
+		if (variant == TowerTranslucentVariant.REAPPEARING_INACTIVE || variant == TowerTranslucentVariant.REAPPEARING_ACTIVE) {
+			return BlockFaceShape.UNDEFINED;
+		} else {
+			return super.getBlockFaceShape(worldIn, state, pos, face);
 		}
 	}
 

--- a/src/main/java/twilightforest/block/BlockTFUberousSoil.java
+++ b/src/main/java/twilightforest/block/BlockTFUberousSoil.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockFarmland;
 import net.minecraft.block.IGrowable;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -46,6 +47,18 @@ public class BlockTFUberousSoil extends Block implements IGrowable, ModelRegiste
 	@Deprecated
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
+	}
+
+	@Override
+	@Deprecated
+	public boolean isFullCube(IBlockState state) {
+		return false;
+	}
+
+	@Override
+	@Deprecated
+	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+		return face == EnumFacing.DOWN ? BlockFaceShape.SOLID : BlockFaceShape.UNDEFINED;
 	}
 
 	@Override


### PR DESCRIPTION
Mojang somewhat unhelpfully made `getBlockFaceShape` always default to `SOLID` so a bunch of stuff needs to override it, mostly to return `UNDEFINED`.

Stops fences attaching to random blocks and things like that.

Also sets `isFullCube` to return false for a few more blocks that aren't full cubes.

Spiral blocks are confusing, but I *think* this is right.