### PR TITLE
Give block and chain the ability to disable shields

### DIFF
--- a/src/main/java/twilightforest/entity/EntityTFChainBlock.java
+++ b/src/main/java/twilightforest/entity/EntityTFChainBlock.java
@@ -20,6 +20,7 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
+import twilightforest.item.TFItems;
 import twilightforest.util.WorldUtil;
 
 
@@ -233,6 +234,15 @@ public class EntityTFChainBlock extends EntityThrowable implements IEntityMultiP
 					this.motionZ = this.velZ * (1.0 - age) + (back.z * 2F * age);
 				}
 			}
+		}
+	}
+
+	@Override
+	public void setDead() {
+		super.setDead();
+		EntityLivingBase thrower = this.getThrower();
+		if (thrower != null && thrower.getActiveItemStack().getItem() == TFItems.chainBlock) {
+			thrower.resetActiveHand();
 		}
 	}
 

--- a/src/main/java/twilightforest/entity/EntityTFChainBlock.java
+++ b/src/main/java/twilightforest/entity/EntityTFChainBlock.java
@@ -76,8 +76,8 @@ public class EntityTFChainBlock extends EntityThrowable implements IEntityMultiP
 		}
 
 		// only hit living things
-		if (mop.entityHit != null && mop.entityHit instanceof EntityLivingBase && mop.entityHit != this.getThrower()) {
-			if (mop.entityHit.attackEntityFrom(DamageSource.causePlayerDamage((EntityPlayer) this.getThrower()), 10)) {
+		if (mop.entityHit instanceof EntityLivingBase && mop.entityHit != this.getThrower()) {
+			if (mop.entityHit.attackEntityFrom(this.getDamageSource(), 10)) {
 				// age when we hit a monster so that we go back to the player faster
 				this.ticksExisted += 60;
 			}
@@ -141,6 +141,17 @@ public class EntityTFChainBlock extends EntityThrowable implements IEntityMultiP
 			if (this.blocksSmashed > MAX_SMASH && this.ticksExisted < 60) {
 				this.ticksExisted += 60;
 			}
+		}
+	}
+
+	private DamageSource getDamageSource() {
+		EntityLivingBase thrower = this.getThrower();
+		if (thrower instanceof EntityPlayer) {
+			return DamageSource.causePlayerDamage((EntityPlayer) thrower);
+		} else if (thrower != null) {
+			return DamageSource.causeMobDamage(thrower);
+		} else {
+			return DamageSource.causeThrownDamage(this, null);
 		}
 	}
 

--- a/src/main/java/twilightforest/entity/EntityTFCubeOfAnnihilation.java
+++ b/src/main/java/twilightforest/entity/EntityTFCubeOfAnnihilation.java
@@ -53,13 +53,23 @@ public class EntityTFCubeOfAnnihilation extends EntityThrowable {
 			return;
 
 		// only hit living things
-		if (mop.entityHit != null && mop.entityHit instanceof EntityLivingBase
-				&& mop.entityHit.attackEntityFrom(DamageSource.causePlayerDamage((EntityPlayer) this.getThrower()), 10)) {
+		if (mop.entityHit instanceof EntityLivingBase && mop.entityHit.attackEntityFrom(this.getDamageSource(), 10)) {
 			this.ticksExisted += 60;
 		}
 
 		if (mop.getBlockPos() != null && !this.world.isAirBlock(mop.getBlockPos())) {
 			this.affectBlocksInAABB(this.getEntityBoundingBox().grow(0.2F, 0.2F, 0.2F));
+		}
+	}
+
+	private DamageSource getDamageSource() {
+		EntityLivingBase thrower = this.getThrower();
+		if (thrower instanceof EntityPlayer) {
+			return DamageSource.causePlayerDamage((EntityPlayer) thrower);
+		} else if (thrower != null) {
+			return DamageSource.causeMobDamage(thrower);
+		} else {
+			return DamageSource.causeThrownDamage(this, null);
 		}
 	}
 

--- a/src/main/java/twilightforest/entity/EntityTFCubeOfAnnihilation.java
+++ b/src/main/java/twilightforest/entity/EntityTFCubeOfAnnihilation.java
@@ -19,6 +19,7 @@ import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import twilightforest.TFPacketHandler;
 import twilightforest.block.BlockTFCastleMagic;
 import twilightforest.block.TFBlocks;
+import twilightforest.item.TFItems;
 import twilightforest.network.PacketAnnihilateBlock;
 import twilightforest.util.WorldUtil;
 
@@ -158,6 +159,15 @@ public class EntityTFCubeOfAnnihilation extends EntityThrowable {
 
 			// demolish some blocks
 			this.affectBlocksInAABB(this.getEntityBoundingBox().grow(0.2F, 0.2F, 0.2F));
+		}
+	}
+
+	@Override
+	public void setDead() {
+		super.setDead();
+		EntityLivingBase thrower = this.getThrower();
+		if (thrower != null && thrower.getActiveItemStack().getItem() == TFItems.cube_of_annihilation) {
+			thrower.resetActiveHand();
 		}
 	}
 

--- a/src/main/java/twilightforest/item/ItemTFChainBlock.java
+++ b/src/main/java/twilightforest/item/ItemTFChainBlock.java
@@ -116,6 +116,11 @@ public class ItemTFChainBlock extends ItemTool implements ModelRegisterCallback 
 	}
 
 	@Override
+	public boolean canDisableShield(ItemStack stack, ItemStack shield, EntityLivingBase entity, EntityLivingBase attacker) {
+		return true;
+	}
+
+	@Override
 	public int getHarvestLevel(ItemStack stack, String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState state) {
 		if ("pickaxe".equals(toolClass)) {
 			return 2;

--- a/src/main/java/twilightforest/item/ItemTFCubeOfAnnihilation.java
+++ b/src/main/java/twilightforest/item/ItemTFCubeOfAnnihilation.java
@@ -101,4 +101,9 @@ public class ItemTFCubeOfAnnihilation extends ItemTF {
 	public EnumAction getItemUseAction(ItemStack par1ItemStack) {
 		return EnumAction.BLOCK;
 	}
+
+	@Override
+	public boolean canDisableShield(ItemStack stack, ItemStack shield, EntityLivingBase entity, EntityLivingBase attacker) {
+		return true;
+	}
 }


### PR DESCRIPTION
Should resolve #483.

Hard to test against an actual blocking player, but tested with debug code added to `EntityTFBighorn` and it seemed to be fine.

The code (condition is from `EntityPlayer.blockUsingShield`):
```java
@Override
public boolean isActiveItemStackBlocking() {
	return true;
}

@Override
protected void blockUsingShield(EntityLivingBase p_190629_1_) {
	super.blockUsingShield(p_190629_1_);
	if (p_190629_1_.getHeldItemMainhand().getItem().canDisableShield(p_190629_1_.getHeldItemMainhand(), this.getActiveItemStack(), this, p_190629_1_)) {
		TwilightForestMod.LOGGER.info("Shield would be disabled here if I wasn't a sheep. Baa.");
	}
}
```

Log message shows up:
```
[twilightforest]: Shield would be disabled here if I wasn't a sheep. Baa.
```

Also made the entity's `onImpact` code providing a damage source a bit safer.