### PR TITLE
Fix #507

### DIFF
--- a/src/main/java/twilightforest/block/BlockTFTrophyPedestal.java
+++ b/src/main/java/twilightforest/block/BlockTFTrophyPedestal.java
@@ -117,7 +117,7 @@ public class BlockTFTrophyPedestal extends Block implements ModelRegisterCallbac
 	}
 
 	private boolean isPlayerEligible(EntityPlayer player) {
-		return TwilightForestMod.proxy.doesPlayerHaveAdvancement(player, new ResourceLocation(TwilightForestMod.ID, "progress_hydra"));
+		return TwilightForestMod.proxy.doesPlayerHaveAdvancement(player, new ResourceLocation(TwilightForestMod.ID, "progress_lich"));
 	}
 
 	private void doPedestalEffect(World world, BlockPos pos, IBlockState state) {

--- a/src/main/resources/assets/twilightforest/lang/en_us.lang
+++ b/src/main/resources/assets/twilightforest/lang/en_us.lang
@@ -98,7 +98,7 @@ advancement.twilight_progress_thorns.desc=Make it past the thornlands, and unloc
 advancement.twilight_progress_castle=So Castle Very Wow [NYI]
 advancement.twilight_progress_castle.desc=What could even be in that castle?!?
 
-twilightforest.trophyPedestal.ineligible=You are unworthy.
+twilightforest.trophy_pedestal.ineligible=You are unworthy.
 twilightforest.ore_meter.range=Radius: %s, Origin: [%s, %s]
 twilightforest.ore_meter.exposed=Exposed: %s
 twilightforest.scepter_charges=%d charges left


### PR DESCRIPTION
This pull request updates the Trophy Pedestal to check for the correct advancement, as it was still checking for `progress_hydra` advancement. It also fixes the ineligibility message, as it seems that the registry name of the Trophy Pedestal was changed. I only touched on `en_us`, so that other PRs that update the lang file are not conflicting.