### PR TITLE
Fix Redcap Sapper and Redcap Goblin boots rendering, the reduxening.

### DIFF
--- a/src/main/java/twilightforest/client/renderer/entity/RenderTFBiped.java
+++ b/src/main/java/twilightforest/client/renderer/entity/RenderTFBiped.java
@@ -3,6 +3,7 @@ package twilightforest.client.renderer.entity;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.entity.RenderBiped;
 import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.client.renderer.entity.layers.LayerBipedArmor;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.ResourceLocation;
 import twilightforest.TwilightForestMod;
@@ -12,6 +13,7 @@ public class RenderTFBiped<T extends EntityLiving> extends RenderBiped<T> {
 
 	public RenderTFBiped(RenderManager manager, ModelBiped modelBiped, float scale, String textureName) {
 		super(manager, modelBiped, scale);
+		this.addLayer(new LayerBipedArmor(this));
 
 		if (textureName.startsWith("textures")) {
 			textureLoc = new ResourceLocation(textureName);


### PR DESCRIPTION
Take two with this PR.

This fixes #240 by adding a line in the `RenderTFBiped` class, which doesn't show any ill effects, but it seems to work.