### PR TITLE
Fix incorrect minotaur drops

### DIFF
--- a/src/main/resources/assets/twilightforest/loot_tables/entities/minotaur.json
+++ b/src/main/resources/assets/twilightforest/loot_tables/entities/minotaur.json
@@ -31,7 +31,7 @@
       ],
       "entries": [{
         "type": "item",
-        "name": "twilightforest:magic_map_focus"
+        "name": "twilightforest:maze_map_focus"
       }]
     }
   ]


### PR DESCRIPTION
For some reason, Minotaurs were dropping Magic Map Focuses