### PR TITLE
Set useNeighborBrightness correctly on opaque non-full blocks

### DIFF
--- a/src/main/java/twilightforest/block/BlockTFAuroraSlab.java
+++ b/src/main/java/twilightforest/block/BlockTFAuroraSlab.java
@@ -37,6 +37,7 @@ public class BlockTFAuroraSlab extends BlockSlab implements ModelRegisterCallbac
 		this.setHardness(2.0F);
 		this.setResistance(10.0F);
 		this.setLightOpacity(isDouble ? 255 : 0);
+		this.useNeighborBrightness = !isDouble;
 
 		IBlockState state = this.blockState.getBaseState().withProperty(VARIANT, AuroraSlabVariant.AURORA);
 

--- a/src/main/java/twilightforest/block/BlockTFCastleStairs.java
+++ b/src/main/java/twilightforest/block/BlockTFCastleStairs.java
@@ -27,6 +27,7 @@ public class BlockTFCastleStairs extends BlockStairs implements ModelRegisterCal
 		this.setSoundType(SoundType.STONE);
 		this.setCreativeTab(TFItems.creativeTab);
 		this.setDefaultState(getDefaultState().withProperty(VARIANT, CastlePillarVariant.ENCASED));
+		this.useNeighborBrightness = true;
 	}
 
 	@Override

--- a/src/main/java/twilightforest/block/BlockTFNagastoneStairs.java
+++ b/src/main/java/twilightforest/block/BlockTFNagastoneStairs.java
@@ -28,6 +28,7 @@ public class BlockTFNagastoneStairs extends BlockStairs implements ModelRegister
 		this.setSoundType(SoundType.STONE);
 		this.setCreativeTab(TFItems.creativeTab);
 		this.setDefaultState(this.getDefaultState().withProperty(DIRECTION, LeftRight.LEFT));
+		this.useNeighborBrightness = true;
 	}
 
 	@Override

--- a/src/main/java/twilightforest/block/BlockTFUberousSoil.java
+++ b/src/main/java/twilightforest/block/BlockTFUberousSoil.java
@@ -33,6 +33,7 @@ public class BlockTFUberousSoil extends Block implements IGrowable, ModelRegiste
 		this.setHardness(0.6F);
 		this.setSoundType(SoundType.GROUND);
 		this.setTickRandomly(true);
+		this.useNeighborBrightness = true;
 
 		this.setCreativeTab(TFItems.creativeTab);
 	}


### PR DESCRIPTION
Fixes these blocks looking bad with smooth lighting disabled.

Before:
![2018-05-27_21 53 30](https://user-images.githubusercontent.com/1447117/40590560-a172c014-61f8-11e8-8c2e-5c904257c69a.png)

After:
![2018-05-27_21 54 50](https://user-images.githubusercontent.com/1447117/40590562-a469e3ce-61f8-11e8-83f1-0a79ce04b595.png)

For whatever reason, vanilla handles this by looping over the initial block registry and setting this flag on each block that matches some conditions, so it needs to be handled by subclasses themselves.