### PR TITLE
Tweak axe damage and speed values to better match vanilla

### DIFF
--- a/src/main/java/twilightforest/item/ItemTFChainBlock.java
+++ b/src/main/java/twilightforest/item/ItemTFChainBlock.java
@@ -31,7 +31,7 @@ public class ItemTFChainBlock extends ItemTool implements ModelRegisterCallback 
 	private static final String THROWN_UUID_KEY = "chainEntity";
 
 	protected ItemTFChainBlock() {
-		super(6, 1.6F, TFItems.TOOL_KNIGHTLY, Sets.newHashSet(Blocks.STONE)); // todo 1.9 attack speed
+		super(6, -3.0F, TFItems.TOOL_KNIGHTLY, Sets.newHashSet(Blocks.STONE));
 		this.maxStackSize = 1;
 		this.setMaxDamage(99);
 		this.setCreativeTab(TFItems.creativeTab);

--- a/src/main/java/twilightforest/item/ItemTFIronwoodAxe.java
+++ b/src/main/java/twilightforest/item/ItemTFIronwoodAxe.java
@@ -11,7 +11,7 @@ import twilightforest.client.ModelRegisterCallback;
 public class ItemTFIronwoodAxe extends ItemAxe implements ModelRegisterCallback {
 
 	protected ItemTFIronwoodAxe(Item.ToolMaterial material) {
-		super(material, 4F + material.getDamageVsEntity(), -3.2F);
+		super(material, 6F + material.getDamageVsEntity(), material.getEfficiencyOnProperMaterial() * 0.05f - 3.4f);
 		this.setCreativeTab(TFItems.creativeTab);
 	}
 

--- a/src/main/java/twilightforest/item/ItemTFKnightlyAxe.java
+++ b/src/main/java/twilightforest/item/ItemTFKnightlyAxe.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class ItemTFKnightlyAxe extends ItemAxe implements ModelRegisterCallback {
 
 	protected ItemTFKnightlyAxe(Item.ToolMaterial material) {
-		super(material, 4F + material.getDamageVsEntity(), -3.0f);
+		super(material, 6F + material.getDamageVsEntity(), material.getEfficiencyOnProperMaterial() * 0.05f - 3.4f);
 		this.setCreativeTab(TFItems.creativeTab);
 	}
 

--- a/src/main/java/twilightforest/item/ItemTFMinotaurAxe.java
+++ b/src/main/java/twilightforest/item/ItemTFMinotaurAxe.java
@@ -27,7 +27,7 @@ public class ItemTFMinotaurAxe extends ItemAxe implements ModelRegisterCallback 
 	private static final int BONUS_CHARGING_DAMAGE = 7;
 
 	protected ItemTFMinotaurAxe(Item.ToolMaterial material) {
-		super(material, 4F + material.getDamageVsEntity(), -3.0f);
+		super(material, 6F + material.getDamageVsEntity(), material.getEfficiencyOnProperMaterial() * 0.05f - 3.4f);
 		this.setCreativeTab(TFItems.creativeTab);
 	}
 

--- a/src/main/java/twilightforest/item/ItemTFSteeleafAxe.java
+++ b/src/main/java/twilightforest/item/ItemTFSteeleafAxe.java
@@ -11,7 +11,7 @@ import twilightforest.client.ModelRegisterCallback;
 public class ItemTFSteeleafAxe extends ItemAxe implements ModelRegisterCallback {
 
 	protected ItemTFSteeleafAxe(Item.ToolMaterial material) {
-		super(material, 4F + material.getDamageVsEntity(), -3.0f);
+		super(material, 6F + material.getDamageVsEntity(), material.getEfficiencyOnProperMaterial() * 0.05f - 3.4f);
 		this.setCreativeTab(TFItems.creativeTab);
 	}
 


### PR DESCRIPTION
This increases the base damage of axes to match vanilla, and makes the attack speed vary based on the material's efficiency value.

The block-and-chain also no longer has a super fast attack speed value.