### PR TITLE
Blacklist surface lakes from some TF biomes

### DIFF
--- a/src/main/java/twilightforest/biomes/TFBiomeClearing.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeClearing.java
@@ -12,7 +12,7 @@ public class TFBiomeClearing extends TFBiomeBase {
 	public TFBiomeClearing(BiomeProperties props) {
 		super(props);
 
-		getTFBiomeDecorator().canopyPerChunk = -999;
+		getTFBiomeDecorator().hasCanopy = false;
 		getTFBiomeDecorator().setTreesPerChunk(-999);
 
 		getTFBiomeDecorator().setFlowersPerChunk(4);

--- a/src/main/java/twilightforest/biomes/TFBiomeFinalPlateau.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeFinalPlateau.java
@@ -22,7 +22,7 @@ public class TFBiomeFinalPlateau extends TFBiomeBase {
 		this.topBlock = TFBlocks.deadrock.getDefaultState().withProperty(BlockTFDeadrock.VARIANT, DeadrockVariant.SURFACE);
 		this.fillerBlock = TFBlocks.deadrock.getDefaultState().withProperty(BlockTFDeadrock.VARIANT, DeadrockVariant.CRACKED);
 
-		((TFBiomeDecorator) decorator).hasCanopy = false;
+		getTFBiomeDecorator().hasCanopy = false;
 		getTFBiomeDecorator().setTreesPerChunk(-999);
 
 		this.decorator.generateFalls = false;

--- a/src/main/java/twilightforest/biomes/TFBiomeFireSwamp.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeFireSwamp.java
@@ -33,7 +33,7 @@ public class TFBiomeFireSwamp extends TFBiomeBase {
 		getTFBiomeDecorator().setTreesPerChunk(3);
 		getTFBiomeDecorator().setWaterlilyPerChunk(6);
 
-		((TFBiomeDecorator) decorator).hasCanopy = false;
+		getTFBiomeDecorator().hasCanopy = false;
 		getTFBiomeDecorator().lavaPoolChance = 0.125F;
 		getTFBiomeDecorator().mangrovesPerChunk = 3;
 	}

--- a/src/main/java/twilightforest/biomes/TFBiomeGlacier.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeGlacier.java
@@ -31,7 +31,7 @@ public class TFBiomeGlacier extends TFBiomeBase {
 		getTFBiomeDecorator().setTreesPerChunk(1);
 		getTFBiomeDecorator().setGrassPerChunk(0);
 
-		((TFBiomeDecorator) decorator).hasCanopy = false;
+		getTFBiomeDecorator().hasCanopy = false;
 
 		spawnableCreatureList.add(new SpawnListEntry(twilightforest.entity.passive.EntityTFPenguin.class, 10, 4, 4));
 

--- a/src/main/java/twilightforest/biomes/TFBiomeHighlands.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeHighlands.java
@@ -47,7 +47,7 @@ public class TFBiomeHighlands extends TFBiomeBase {
 	public TFBiomeHighlands(BiomeProperties props) {
 		super(props);
 
-		((TFBiomeDecorator) decorator).hasCanopy = false;
+		getTFBiomeDecorator().hasCanopy = false;
 
 		this.decorator.grassPerChunk = 7;
 		this.decorator.deadBushPerChunk = 1;

--- a/src/main/java/twilightforest/biomes/TFBiomeSnow.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeSnow.java
@@ -40,7 +40,7 @@ public class TFBiomeSnow extends TFBiomeBase {
 		getTFBiomeDecorator().setTreesPerChunk(7);
 		getTFBiomeDecorator().setGrassPerChunk(1);
 
-		((TFBiomeDecorator) decorator).hasCanopy = false;
+		getTFBiomeDecorator().hasCanopy = false;
 		getTFBiomeDecorator().generateFalls = false;
 
 		this.spawnableMonsterList.add(new SpawnListEntry(EntityTFYeti.class, 20, 4, 4));

--- a/src/main/java/twilightforest/biomes/TFBiomeSwamp.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeSwamp.java
@@ -56,7 +56,7 @@ public class TFBiomeSwamp extends TFBiomeBase {
 		getTFBiomeDecorator().setWaterlilyPerChunk(20);
 
 
-		((TFBiomeDecorator) decorator).hasCanopy = false;
+		getTFBiomeDecorator().hasCanopy = false;
 		getTFBiomeDecorator().lakesPerChunk = 2;
 		getTFBiomeDecorator().mangrovesPerChunk = 3;
 

--- a/src/main/java/twilightforest/biomes/TFBiomeThornlands.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeThornlands.java
@@ -32,7 +32,7 @@ public class TFBiomeThornlands extends TFBiomeBase {
 		this.topBlock = TFBlocks.deadrock.getDefaultState().withProperty(BlockTFDeadrock.VARIANT, DeadrockVariant.SURFACE);
 		this.fillerBlock = TFBlocks.deadrock.getDefaultState().withProperty(BlockTFDeadrock.VARIANT, DeadrockVariant.CRACKED);
 
-		((TFBiomeDecorator) decorator).hasCanopy = false;
+		getTFBiomeDecorator().hasCanopy = false;
 		getTFBiomeDecorator().setTreesPerChunk(-999);
 		this.decorator.deadBushPerChunk = 2;
 		this.decorator.cactiPerChunk = -9999;

--- a/src/main/java/twilightforest/world/ChunkGeneratorTwilightForest.java
+++ b/src/main/java/twilightforest/world/ChunkGeneratorTwilightForest.java
@@ -29,6 +29,7 @@ import net.minecraft.world.gen.structure.StructureBoundingBox;
 import twilightforest.TFConfig;
 import twilightforest.TFFeature;
 import twilightforest.biomes.TFBiomeBase;
+import twilightforest.biomes.TFBiomeDecorator;
 import twilightforest.biomes.TFBiomes;
 import twilightforest.block.TFBlocks;
 
@@ -785,11 +786,13 @@ public class ChunkGeneratorTwilightForest implements IChunkGenerator {
 
 		hollowTreeGenerator.generateStructure(world, rand, chunkpos);
 
-		if (!disableFeatures && rand.nextInt(4) == 0 && biome.decorator.generateFalls) {
+		if (!disableFeatures && rand.nextInt(4) == 0) {
 			int i1 = blockpos.getX() + rand.nextInt(16) + 8;
 			int i2 = rand.nextInt(TFWorld.CHUNKHEIGHT);
 			int i3 = blockpos.getZ() + rand.nextInt(16) + 8;
-			(new WorldGenLakes(Blocks.WATER)).generate(world, rand, new BlockPos(i1, i2, i3));
+			if (i2 < TFWorld.SEALEVEL || allowSurfaceLakes(biome)) {
+				(new WorldGenLakes(Blocks.WATER)).generate(world, rand, new BlockPos(i1, i2, i3));
+			}
 		}
 
 		if (!disableFeatures && rand.nextInt(32) == 0) // reduced from 8
@@ -797,7 +800,7 @@ public class ChunkGeneratorTwilightForest implements IChunkGenerator {
 			int j1 = blockpos.getX() + rand.nextInt(16) + 8;
 			int j2 = rand.nextInt(rand.nextInt(TFWorld.CHUNKHEIGHT - 8) + 8);
 			int j3 = blockpos.getZ() + rand.nextInt(16) + 8;
-			if (j2 < TFWorld.SEALEVEL || rand.nextInt(10) == 0) {
+			if (j2 < TFWorld.SEALEVEL || allowSurfaceLakes(biome) && rand.nextInt(10) == 0) {
 				(new WorldGenLakes(Blocks.LAVA)).generate(world, rand, new BlockPos(j1, j2, j3));
 			}
 		}
@@ -838,6 +841,13 @@ public class ChunkGeneratorTwilightForest implements IChunkGenerator {
 		net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.world, this.rand, chunkX, chunkZ, flag);
 
 		BlockFalling.fallInstantly = false;
+	}
+
+	private boolean allowSurfaceLakes(Biome biome) {
+		if (biome.decorator instanceof TFBiomeDecorator) {
+			return !((TFBiomeDecorator) biome.decorator).hasCanopy;
+		}
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Should fix #450.

Prevents lakes generating above sealevel in biomes which have `hasCanopy` true.

(all TF biomes except these)
![biomes](https://user-images.githubusercontent.com/1447117/40862230-c65745e6-65e3-11e8-9348-2645987d2d7f.PNG)

Does this approach seem ok to everyone?