### PR TITLE
Removed a lot of redundant code in advancement triggers

### DIFF
--- a/src/main/java/twilightforest/advancements/ActivateGhastTrapTrigger.java
+++ b/src/main/java/twilightforest/advancements/ActivateGhastTrapTrigger.java
@@ -1,24 +1,14 @@
 package twilightforest.advancements;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
-import net.minecraft.advancements.ICriterionTrigger;
-import net.minecraft.advancements.PlayerAdvancements;
 import net.minecraft.advancements.critereon.AbstractCriterionInstance;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
 import twilightforest.TwilightForestMod;
 
-import java.util.Map;
-import java.util.Set;
-
-public class ActivateGhastTrapTrigger implements ICriterionTrigger<ActivateGhastTrapTrigger.Instance> {
+public class ActivateGhastTrapTrigger extends TriggerTFSimple<ActivateGhastTrapTrigger.Instance> {
 
     public static final ResourceLocation ID = new ResourceLocation(TwilightForestMod.ID, "activate_ghast_trap");
-    private final Map<PlayerAdvancements, ActivateGhastTrapTrigger.Listeners> listeners = Maps.newHashMap();
 
     @Override
     public ResourceLocation getId() {
@@ -26,71 +16,14 @@ public class ActivateGhastTrapTrigger implements ICriterionTrigger<ActivateGhast
     }
 
     @Override
-    public void addListener(PlayerAdvancements playerAdvancementsIn, Listener<ActivateGhastTrapTrigger.Instance> listener) {
-        ActivateGhastTrapTrigger.Listeners listeners = this.listeners.computeIfAbsent(playerAdvancementsIn, Listeners::new);
-        listeners.add(listener);
-    }
-
-    @Override
-    public void removeListener(PlayerAdvancements playerAdvancementsIn, Listener<ActivateGhastTrapTrigger.Instance> listener) {
-        ActivateGhastTrapTrigger.Listeners listeners = this.listeners.get(playerAdvancementsIn);
-        if (listeners != null) {
-            listeners.remove(listener);
-            if (listeners.isEmpty()) {
-                this.listeners.remove(playerAdvancementsIn);
-            }
-        }
-    }
-
-    @Override
-    public void removeAllListeners(PlayerAdvancements playerAdvancementsIn) {
-        this.listeners.remove(playerAdvancementsIn);
-    }
-
-    @Override
     public ActivateGhastTrapTrigger.Instance deserializeInstance(JsonObject json, JsonDeserializationContext context) {
         return new ActivateGhastTrapTrigger.Instance();
-    }
-
-    public void trigger(EntityPlayerMP player) {
-        ActivateGhastTrapTrigger.Listeners listeners = this.listeners.get(player.getAdvancements());
-        if (listeners != null) {
-            listeners.trigger();
-        }
     }
 
     public static class Instance extends AbstractCriterionInstance {
 
         public Instance() {
             super(ActivateGhastTrapTrigger.ID);
-        }
-    }
-
-    static class Listeners {
-
-        private final PlayerAdvancements playerAdvancements;
-        private final Set<Listener<ActivateGhastTrapTrigger.Instance>> listeners = Sets.newHashSet();
-
-        public Listeners(PlayerAdvancements playerAdvancementsIn) {
-            this.playerAdvancements = playerAdvancementsIn;
-        }
-
-        public boolean isEmpty() {
-            return this.listeners.isEmpty();
-        }
-
-        public void add(Listener<ActivateGhastTrapTrigger.Instance> listener) {
-            this.listeners.add(listener);
-        }
-
-        public void remove(Listener<ActivateGhastTrapTrigger.Instance> listener) {
-            this.listeners.remove(listener);
-        }
-
-        public void trigger() {
-            for (Listener<ActivateGhastTrapTrigger.Instance> listener : Lists.newArrayList(this.listeners)) {
-                listener.grantCriterion(this.playerAdvancements);
-            }
         }
     }
 }

--- a/src/main/java/twilightforest/advancements/HasAdvancementTrigger.java
+++ b/src/main/java/twilightforest/advancements/HasAdvancementTrigger.java
@@ -1,7 +1,5 @@
 package twilightforest.advancements;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
 import net.minecraft.advancements.ICriterionTrigger;
@@ -14,39 +12,14 @@ import twilightforest.TwilightForestMod;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-public class HasAdvancementTrigger implements ICriterionTrigger<HasAdvancementTrigger.Instance> {
+public class HasAdvancementTrigger extends TriggerTF<HasAdvancementTrigger.Instance> {
 
     private static final ResourceLocation ID = new ResourceLocation(TwilightForestMod.ID, "has_advancement");
-    private final Map<PlayerAdvancements, HasAdvancementTrigger.Listeners> listeners = Maps.newHashMap();
 
     @Override
     public ResourceLocation getId() {
         return ID;
-    }
-
-    @Override
-    public void addListener(PlayerAdvancements playerAdvancementsIn, Listener<Instance> listener) {
-        HasAdvancementTrigger.Listeners listeners = this.listeners.computeIfAbsent(playerAdvancementsIn, Listeners::new);
-        listeners.add(listener);
-    }
-
-    @Override
-    public void removeListener(PlayerAdvancements playerAdvancementsIn, ICriterionTrigger.Listener<HasAdvancementTrigger.Instance> listener) {
-        HasAdvancementTrigger.Listeners listeners = this.listeners.get(playerAdvancementsIn);
-        if (listeners != null) {
-            listeners.remove(listener);
-            if (listeners.isEmpty()) {
-                this.listeners.remove(playerAdvancementsIn);
-            }
-        }
-    }
-
-    @Override
-    public void removeAllListeners(PlayerAdvancements playerAdvancementsIn) {
-        this.listeners.remove(playerAdvancementsIn);
     }
 
     @Override
@@ -56,7 +29,7 @@ public class HasAdvancementTrigger implements ICriterionTrigger<HasAdvancementTr
     }
 
     public void trigger(EntityPlayerMP player) {
-        Listeners l = listeners.get(player.getAdvancements());
+        Listeners l = (Listeners) listeners.get(player.getAdvancements());
         if (l != null) {
             l.trigger(player);
         }
@@ -76,25 +49,10 @@ public class HasAdvancementTrigger implements ICriterionTrigger<HasAdvancementTr
         }
     }
 
-    private static class Listeners {
-
-        private final PlayerAdvancements playerAdvancements;
-        private final Set<Listener<HasAdvancementTrigger.Instance>> listeners = Sets.newHashSet();
+    private static class Listeners extends TriggerTF.Listeners<HasAdvancementTrigger.Instance> {
 
         Listeners(PlayerAdvancements playerAdvancements) {
-            this.playerAdvancements = playerAdvancements;
-        }
-
-        public boolean isEmpty() {
-            return this.listeners.isEmpty();
-        }
-
-        public void add(ICriterionTrigger.Listener<HasAdvancementTrigger.Instance> listener) {
-            this.listeners.add(listener);
-        }
-
-        public void remove(ICriterionTrigger.Listener<HasAdvancementTrigger.Instance> listener) {
-            this.listeners.remove(listener);
+            super(playerAdvancements);
         }
 
         public void trigger(EntityPlayerMP player) {

--- a/src/main/java/twilightforest/advancements/HydraChopTrigger.java
+++ b/src/main/java/twilightforest/advancements/HydraChopTrigger.java
@@ -1,24 +1,14 @@
 package twilightforest.advancements;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
-import net.minecraft.advancements.ICriterionTrigger;
-import net.minecraft.advancements.PlayerAdvancements;
 import net.minecraft.advancements.critereon.AbstractCriterionInstance;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
 import twilightforest.TwilightForestMod;
 
-import java.util.Map;
-import java.util.Set;
-
-public class HydraChopTrigger implements ICriterionTrigger<HydraChopTrigger.Instance> {
+public class HydraChopTrigger extends TriggerTFSimple<HydraChopTrigger.Instance> {
 
     public static final ResourceLocation ID = new ResourceLocation(TwilightForestMod.ID, "consume_hydra_chop_on_low_hunger");
-    private final Map<PlayerAdvancements, HydraChopTrigger.Listeners> listeners = Maps.newHashMap();
 
     @Override
     public ResourceLocation getId() {
@@ -26,71 +16,14 @@ public class HydraChopTrigger implements ICriterionTrigger<HydraChopTrigger.Inst
     }
 
     @Override
-    public void addListener(PlayerAdvancements playerAdvancementsIn, Listener<HydraChopTrigger.Instance> listener) {
-        HydraChopTrigger.Listeners listeners = this.listeners.computeIfAbsent(playerAdvancementsIn, Listeners::new);
-        listeners.add(listener);
-    }
-
-    @Override
-    public void removeListener(PlayerAdvancements playerAdvancementsIn, Listener<HydraChopTrigger.Instance> listener) {
-        HydraChopTrigger.Listeners listeners = this.listeners.get(playerAdvancementsIn);
-        if (listeners != null) {
-            listeners.remove(listener);
-            if (listeners.isEmpty()) {
-                this.listeners.remove(playerAdvancementsIn);
-            }
-        }
-    }
-
-    @Override
-    public void removeAllListeners(PlayerAdvancements playerAdvancementsIn) {
-        this.listeners.remove(playerAdvancementsIn);
-    }
-
-    @Override
     public HydraChopTrigger.Instance deserializeInstance(JsonObject json, JsonDeserializationContext context) {
         return new HydraChopTrigger.Instance();
-    }
-
-    public void trigger(EntityPlayerMP player) {
-        HydraChopTrigger.Listeners listeners = this.listeners.get(player.getAdvancements());
-        if (listeners != null) {
-            listeners.trigger();
-        }
     }
 
     public static class Instance extends AbstractCriterionInstance {
 
         public Instance() {
             super(HydraChopTrigger.ID);
-        }
-    }
-
-    static class Listeners {
-
-        private final PlayerAdvancements playerAdvancements;
-        private final Set<Listener<HydraChopTrigger.Instance>> listeners = Sets.newHashSet();
-
-        public Listeners(PlayerAdvancements playerAdvancementsIn) {
-            this.playerAdvancements = playerAdvancementsIn;
-        }
-
-        public boolean isEmpty() {
-            return this.listeners.isEmpty();
-        }
-
-        public void add(Listener<HydraChopTrigger.Instance> listener) {
-            this.listeners.add(listener);
-        }
-
-        public void remove(Listener<HydraChopTrigger.Instance> listener) {
-            this.listeners.remove(listener);
-        }
-
-        public void trigger() {
-            for (Listener<HydraChopTrigger.Instance> listener : Lists.newArrayList(this.listeners)) {
-                listener.grantCriterion(this.playerAdvancements);
-            }
         }
     }
 }

--- a/src/main/java/twilightforest/advancements/MakePortalTrigger.java
+++ b/src/main/java/twilightforest/advancements/MakePortalTrigger.java
@@ -1,24 +1,14 @@
 package twilightforest.advancements;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
-import java.util.Map;
-import java.util.Set;
-
-import net.minecraft.advancements.ICriterionTrigger;
-import net.minecraft.advancements.PlayerAdvancements;
 import net.minecraft.advancements.critereon.AbstractCriterionInstance;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
 import twilightforest.TwilightForestMod;
 
-public class MakePortalTrigger implements ICriterionTrigger<MakePortalTrigger.Instance> {
+public class MakePortalTrigger extends TriggerTFSimple<MakePortalTrigger.Instance> {
 
     public static final ResourceLocation ID = new ResourceLocation(TwilightForestMod.ID, "make_tf_portal");
-    private final Map<PlayerAdvancements, MakePortalTrigger.Listeners> listeners = Maps.newHashMap();
 
     @Override
     public ResourceLocation getId() {
@@ -26,71 +16,14 @@ public class MakePortalTrigger implements ICriterionTrigger<MakePortalTrigger.In
     }
 
     @Override
-    public void addListener(PlayerAdvancements playerAdvancementsIn, ICriterionTrigger.Listener<MakePortalTrigger.Instance> listener) {
-        MakePortalTrigger.Listeners listeners = this.listeners.computeIfAbsent(playerAdvancementsIn, Listeners::new);
-        listeners.add(listener);
-    }
-
-    @Override
-    public void removeListener(PlayerAdvancements playerAdvancementsIn, ICriterionTrigger.Listener<MakePortalTrigger.Instance> listener) {
-        MakePortalTrigger.Listeners listeners = this.listeners.get(playerAdvancementsIn);
-        if (listeners != null) {
-            listeners.remove(listener);
-            if (listeners.isEmpty()) {
-                this.listeners.remove(playerAdvancementsIn);
-            }
-        }
-    }
-
-    @Override
-    public void removeAllListeners(PlayerAdvancements playerAdvancementsIn) {
-        this.listeners.remove(playerAdvancementsIn);
-    }
-
-    @Override
     public MakePortalTrigger.Instance deserializeInstance(JsonObject json, JsonDeserializationContext context) {
         return new MakePortalTrigger.Instance();
-    }
-
-    public void trigger(EntityPlayerMP player) {
-        MakePortalTrigger.Listeners listeners = this.listeners.get(player.getAdvancements());
-        if (listeners != null) {
-            listeners.trigger();
-        }
     }
 
     public static class Instance extends AbstractCriterionInstance {
 
         public Instance() {
             super(MakePortalTrigger.ID);
-        }
-    }
-
-    static class Listeners {
-
-        private final PlayerAdvancements playerAdvancements;
-        private final Set<ICriterionTrigger.Listener<MakePortalTrigger.Instance>> listeners = Sets.newHashSet();
-
-        public Listeners(PlayerAdvancements playerAdvancementsIn) {
-            this.playerAdvancements = playerAdvancementsIn;
-        }
-
-        public boolean isEmpty() {
-            return this.listeners.isEmpty();
-        }
-
-        public void add(ICriterionTrigger.Listener<MakePortalTrigger.Instance> listener) {
-            this.listeners.add(listener);
-        }
-
-        public void remove(ICriterionTrigger.Listener<MakePortalTrigger.Instance> listener) {
-            this.listeners.remove(listener);
-        }
-
-        public void trigger() {
-            for (ICriterionTrigger.Listener<MakePortalTrigger.Instance> listener : Lists.newArrayList(this.listeners)) {
-                listener.grantCriterion(this.playerAdvancements);
-            }
         }
     }
 }

--- a/src/main/java/twilightforest/advancements/QuestRamCompletionTrigger.java
+++ b/src/main/java/twilightforest/advancements/QuestRamCompletionTrigger.java
@@ -1,24 +1,14 @@
 package twilightforest.advancements;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
-import net.minecraft.advancements.ICriterionTrigger;
-import net.minecraft.advancements.PlayerAdvancements;
 import net.minecraft.advancements.critereon.AbstractCriterionInstance;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
 import twilightforest.TwilightForestMod;
 
-import java.util.Map;
-import java.util.Set;
-
-public class QuestRamCompletionTrigger implements ICriterionTrigger<QuestRamCompletionTrigger.Instance> {
+public class QuestRamCompletionTrigger extends TriggerTFSimple<QuestRamCompletionTrigger.Instance> {
 
     public static final ResourceLocation ID = new ResourceLocation(TwilightForestMod.ID, "complete_quest_ram");
-    private final Map<PlayerAdvancements, QuestRamCompletionTrigger.Listeners> listeners = Maps.newHashMap();
 
     @Override
     public ResourceLocation getId() {
@@ -26,71 +16,14 @@ public class QuestRamCompletionTrigger implements ICriterionTrigger<QuestRamComp
     }
 
     @Override
-    public void addListener(PlayerAdvancements playerAdvancementsIn, Listener<QuestRamCompletionTrigger.Instance> listener) {
-        QuestRamCompletionTrigger.Listeners listeners = this.listeners.computeIfAbsent(playerAdvancementsIn, Listeners::new);
-        listeners.add(listener);
-    }
-
-    @Override
-    public void removeListener(PlayerAdvancements playerAdvancementsIn, Listener<QuestRamCompletionTrigger.Instance> listener) {
-        QuestRamCompletionTrigger.Listeners listeners = this.listeners.get(playerAdvancementsIn);
-        if (listeners != null) {
-            listeners.remove(listener);
-            if (listeners.isEmpty()) {
-                this.listeners.remove(playerAdvancementsIn);
-            }
-        }
-    }
-
-    @Override
-    public void removeAllListeners(PlayerAdvancements playerAdvancementsIn) {
-        this.listeners.remove(playerAdvancementsIn);
-    }
-
-    @Override
     public QuestRamCompletionTrigger.Instance deserializeInstance(JsonObject json, JsonDeserializationContext context) {
         return new QuestRamCompletionTrigger.Instance();
-    }
-
-    public void trigger(EntityPlayerMP player) {
-        QuestRamCompletionTrigger.Listeners listeners = this.listeners.get(player.getAdvancements());
-        if (listeners != null) {
-            listeners.trigger();
-        }
     }
 
     public static class Instance extends AbstractCriterionInstance {
 
         public Instance() {
             super(QuestRamCompletionTrigger.ID);
-        }
-    }
-
-    static class Listeners {
-
-        private final PlayerAdvancements playerAdvancements;
-        private final Set<Listener<QuestRamCompletionTrigger.Instance>> listeners = Sets.newHashSet();
-
-        public Listeners(PlayerAdvancements playerAdvancementsIn) {
-            this.playerAdvancements = playerAdvancementsIn;
-        }
-
-        public boolean isEmpty() {
-            return this.listeners.isEmpty();
-        }
-
-        public void add(Listener<QuestRamCompletionTrigger.Instance> listener) {
-            this.listeners.add(listener);
-        }
-
-        public void remove(Listener<QuestRamCompletionTrigger.Instance> listener) {
-            this.listeners.remove(listener);
-        }
-
-        public void trigger() {
-            for (Listener<QuestRamCompletionTrigger.Instance> listener : Lists.newArrayList(this.listeners)) {
-                listener.grantCriterion(this.playerAdvancements);
-            }
         }
     }
 }

--- a/src/main/java/twilightforest/advancements/StructureClearedTrigger.java
+++ b/src/main/java/twilightforest/advancements/StructureClearedTrigger.java
@@ -1,7 +1,5 @@
 package twilightforest.advancements;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
 import net.minecraft.advancements.ICriterionTrigger;
@@ -14,102 +12,62 @@ import twilightforest.TwilightForestMod;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-public class StructureClearedTrigger implements ICriterionTrigger<StructureClearedTrigger.Instance> {
+public class StructureClearedTrigger extends TriggerTF<StructureClearedTrigger.Instance> {
 
-	public static final ResourceLocation ID = new ResourceLocation(TwilightForestMod.ID, "structure_cleared");
-	private final Map<PlayerAdvancements, StructureClearedTrigger.Listeners> listeners = Maps.newHashMap();
+    public static final ResourceLocation ID = new ResourceLocation(TwilightForestMod.ID, "structure_cleared");
 
-	@Override
-	public ResourceLocation getId() {
-		return ID;
-	}
+    @Override
+    public ResourceLocation getId() {
+        return ID;
+    }
 
-	@Override
-	public void addListener(PlayerAdvancements playerAdvancementsIn, Listener<StructureClearedTrigger.Instance> listener) {
-		StructureClearedTrigger.Listeners listeners = this.listeners.computeIfAbsent(playerAdvancementsIn, Listeners::new);
-		listeners.add(listener);
-	}
+    @Override
+    public StructureClearedTrigger.Instance deserializeInstance(JsonObject json, JsonDeserializationContext context) {
+        String structureName = JsonUtils.getString(json, "structure");
+        return new StructureClearedTrigger.Instance(structureName);
+    }
 
-	@Override
-	public void removeListener(PlayerAdvancements playerAdvancementsIn, Listener<StructureClearedTrigger.Instance> listener) {
-		StructureClearedTrigger.Listeners listeners = this.listeners.get(playerAdvancementsIn);
-		if (listeners != null) {
-			listeners.remove(listener);
-			if (listeners.isEmpty()) {
-				this.listeners.remove(playerAdvancementsIn);
-			}
-		}
-	}
+    public void trigger(EntityPlayerMP player, String structureName) {
+        StructureClearedTrigger.Listeners listeners = (StructureClearedTrigger.Listeners) this.listeners.get(player.getAdvancements());
+        if (listeners != null) {
+            listeners.trigger(structureName);
+        }
+    }
 
-	@Override
-	public void removeAllListeners(PlayerAdvancements playerAdvancementsIn) {
-		this.listeners.remove(playerAdvancementsIn);
-	}
+    public static class Instance extends AbstractCriterionInstance {
 
-	@Override
-	public StructureClearedTrigger.Instance deserializeInstance(JsonObject json, JsonDeserializationContext context) {
-		String structureName = JsonUtils.getString(json, "structure");
-		return new StructureClearedTrigger.Instance(structureName);
-	}
+        private final String structureName;
 
-	public void trigger(EntityPlayerMP player, String structureName) {
-		StructureClearedTrigger.Listeners listeners = this.listeners.get(player.getAdvancements());
-		if (listeners != null) {
-			listeners.trigger(structureName);
-		}
-	}
+        public Instance(String structureName) {
+            super(StructureClearedTrigger.ID);
+            this.structureName = structureName;
+        }
 
-	public static class Instance extends AbstractCriterionInstance {
+        boolean test(String structureName) {
+            return this.structureName.equals(structureName);
+        }
+    }
 
-		private final String structureName;
+    static class Listeners extends TriggerTF.Listeners<StructureClearedTrigger.Instance> {
 
-		public Instance(String structureName) {
-			super(StructureClearedTrigger.ID);
-			this.structureName = structureName;
-		}
+        public Listeners(PlayerAdvancements playerAdvancementsIn) {
+            super(playerAdvancementsIn);
+        }
 
-		boolean test(String structureName) {
-			return this.structureName.equals(structureName);
-		}
-	}
+        public void trigger(String structureName) {
 
-	static class Listeners {
+            List<Listener<StructureClearedTrigger.Instance>> list = new ArrayList<>();
 
-		private final PlayerAdvancements playerAdvancements;
-		private final Set<Listener<StructureClearedTrigger.Instance>> listeners = Sets.newHashSet();
+            for (ICriterionTrigger.Listener<StructureClearedTrigger.Instance> listener : this.listeners) {
+                if (listener.getCriterionInstance().test(structureName)) {
+                    list.add(listener);
+                }
+            }
 
-		public Listeners(PlayerAdvancements playerAdvancementsIn) {
-			this.playerAdvancements = playerAdvancementsIn;
-		}
-
-		public boolean isEmpty() {
-			return this.listeners.isEmpty();
-		}
-
-		public void add(Listener<StructureClearedTrigger.Instance> listener) {
-			this.listeners.add(listener);
-		}
-
-		public void remove(Listener<StructureClearedTrigger.Instance> listener) {
-			this.listeners.remove(listener);
-		}
-
-		public void trigger(String structureName) {
-
-			List<Listener<StructureClearedTrigger.Instance>> list = new ArrayList<>();
-
-			for (ICriterionTrigger.Listener<StructureClearedTrigger.Instance> listener : this.listeners) {
-				if (listener.getCriterionInstance().test(structureName)) {
-					list.add(listener);
-				}
-			}
-
-			for (ICriterionTrigger.Listener<StructureClearedTrigger.Instance> listener : list) {
-				listener.grantCriterion(this.playerAdvancements);
-			}
-		}
-	}
+            for (ICriterionTrigger.Listener<StructureClearedTrigger.Instance> listener : list) {
+                listener.grantCriterion(this.playerAdvancements);
+            }
+        }
+    }
 }

--- a/src/main/java/twilightforest/advancements/TriggerTF.java
+++ b/src/main/java/twilightforest/advancements/TriggerTF.java
@@ -1,0 +1,68 @@
+package twilightforest.advancements;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import net.minecraft.advancements.ICriterionInstance;
+import net.minecraft.advancements.ICriterionTrigger;
+import net.minecraft.advancements.PlayerAdvancements;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.Map;
+import java.util.Set;
+
+public abstract class TriggerTF<T extends ICriterionInstance> implements ICriterionTrigger<T> {
+
+    final Map<PlayerAdvancements, Listeners<T>> listeners = Maps.newHashMap();
+
+    @Override
+    public abstract ResourceLocation getId();
+
+    @Override
+    public void addListener(PlayerAdvancements playerAdvancementsIn, Listener<T> listener) {
+        TriggerTF.Listeners<T> listeners = this.listeners.computeIfAbsent(playerAdvancementsIn, Listeners::new);
+        listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(PlayerAdvancements playerAdvancementsIn, Listener<T> listener) {
+        TriggerTF.Listeners<T> listeners = this.listeners.get(playerAdvancementsIn);
+        if (listeners != null) {
+            listeners.remove(listener);
+            if (listeners.isEmpty()) {
+                this.listeners.remove(playerAdvancementsIn);
+            }
+        }
+    }
+
+    @Override
+    public void removeAllListeners(PlayerAdvancements playerAdvancementsIn) {
+        this.listeners.remove(playerAdvancementsIn);
+    }
+
+    @Override
+    public abstract T deserializeInstance(JsonObject json, JsonDeserializationContext context);
+
+    static class Listeners<T extends ICriterionInstance> {
+
+        final PlayerAdvancements playerAdvancements;
+        final Set<Listener<T>> listeners = Sets.newHashSet();
+
+        public Listeners(PlayerAdvancements playerAdvancementsIn) {
+            this.playerAdvancements = playerAdvancementsIn;
+        }
+
+        public boolean isEmpty() {
+            return this.listeners.isEmpty();
+        }
+
+        public void add(Listener<T> listener) {
+            this.listeners.add(listener);
+        }
+
+        public void remove(Listener<T> listener) {
+            this.listeners.remove(listener);
+        }
+    }
+}

--- a/src/main/java/twilightforest/advancements/TriggerTFSimple.java
+++ b/src/main/java/twilightforest/advancements/TriggerTFSimple.java
@@ -1,0 +1,29 @@
+package twilightforest.advancements;
+
+import com.google.common.collect.Lists;
+import net.minecraft.advancements.ICriterionInstance;
+import net.minecraft.advancements.PlayerAdvancements;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+public abstract class TriggerTFSimple<T extends ICriterionInstance> extends TriggerTF<T> {
+
+    public void trigger(EntityPlayerMP player) {
+        Listeners<T> listeners = (Listeners<T>) this.listeners.get(player.getAdvancements());
+        if (listeners != null) {
+            listeners.trigger();
+        }
+    }
+
+    static class Listeners<T extends ICriterionInstance> extends TriggerTF.Listeners<T> {
+
+        public Listeners(PlayerAdvancements playerAdvancementsIn) {
+            super(playerAdvancementsIn);
+        }
+
+        public void trigger() {
+            for (Listener<T> listener : Lists.newArrayList(this.listeners)) {
+                listener.grantCriterion(this.playerAdvancements);
+            }
+        }
+    }
+}

--- a/src/main/java/twilightforest/advancements/TrophyPedestalTrigger.java
+++ b/src/main/java/twilightforest/advancements/TrophyPedestalTrigger.java
@@ -1,24 +1,14 @@
 package twilightforest.advancements;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
-import net.minecraft.advancements.ICriterionTrigger;
-import net.minecraft.advancements.PlayerAdvancements;
 import net.minecraft.advancements.critereon.AbstractCriterionInstance;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
 import twilightforest.TwilightForestMod;
 
-import java.util.Map;
-import java.util.Set;
-
-public class TrophyPedestalTrigger implements ICriterionTrigger<TrophyPedestalTrigger.Instance> {
+public class TrophyPedestalTrigger extends TriggerTFSimple<TrophyPedestalTrigger.Instance> {
 
     public static final ResourceLocation ID = new ResourceLocation(TwilightForestMod.ID, "placed_on_trophy_pedestal");
-    private final Map<PlayerAdvancements, TrophyPedestalTrigger.Listeners> listeners = Maps.newHashMap();
 
     @Override
     public ResourceLocation getId() {
@@ -26,71 +16,14 @@ public class TrophyPedestalTrigger implements ICriterionTrigger<TrophyPedestalTr
     }
 
     @Override
-    public void addListener(PlayerAdvancements playerAdvancementsIn, Listener<TrophyPedestalTrigger.Instance> listener) {
-        TrophyPedestalTrigger.Listeners listeners = this.listeners.computeIfAbsent(playerAdvancementsIn, Listeners::new);
-        listeners.add(listener);
-    }
-
-    @Override
-    public void removeListener(PlayerAdvancements playerAdvancementsIn, Listener<TrophyPedestalTrigger.Instance> listener) {
-        TrophyPedestalTrigger.Listeners listeners = this.listeners.get(playerAdvancementsIn);
-        if (listeners != null) {
-            listeners.remove(listener);
-            if (listeners.isEmpty()) {
-                this.listeners.remove(playerAdvancementsIn);
-            }
-        }
-    }
-
-    @Override
-    public void removeAllListeners(PlayerAdvancements playerAdvancementsIn) {
-        this.listeners.remove(playerAdvancementsIn);
-    }
-
-    @Override
     public TrophyPedestalTrigger.Instance deserializeInstance(JsonObject json, JsonDeserializationContext context) {
         return new TrophyPedestalTrigger.Instance();
-    }
-
-    public void trigger(EntityPlayerMP player) {
-        TrophyPedestalTrigger.Listeners listeners = this.listeners.get(player.getAdvancements());
-        if (listeners != null) {
-            listeners.trigger();
-        }
     }
 
     public static class Instance extends AbstractCriterionInstance {
 
         public Instance() {
             super(TrophyPedestalTrigger.ID);
-        }
-    }
-
-    static class Listeners {
-
-        private final PlayerAdvancements playerAdvancements;
-        private final Set<Listener<TrophyPedestalTrigger.Instance>> listeners = Sets.newHashSet();
-
-        public Listeners(PlayerAdvancements playerAdvancementsIn) {
-            this.playerAdvancements = playerAdvancementsIn;
-        }
-
-        public boolean isEmpty() {
-            return this.listeners.isEmpty();
-        }
-
-        public void add(Listener<TrophyPedestalTrigger.Instance> listener) {
-            this.listeners.add(listener);
-        }
-
-        public void remove(Listener<TrophyPedestalTrigger.Instance> listener) {
-            this.listeners.remove(listener);
-        }
-
-        public void trigger() {
-            for (Listener<TrophyPedestalTrigger.Instance> listener : Lists.newArrayList(this.listeners)) {
-                listener.grantCriterion(this.playerAdvancements);
-            }
         }
     }
 }


### PR DESCRIPTION
This also makes adding new triggers much easier.

Drullkus asked me to contribute to twilight forest, so.

StructureClearedTrigger was initially indented with tabs. I changed it to 4 spaces instead.