### PR TITLE
Rename Highlands Center to Final Plateau

### DIFF
--- a/src/main/java/twilightforest/biomes/RegistryBiomeEvent.java
+++ b/src/main/java/twilightforest/biomes/RegistryBiomeEvent.java
@@ -213,7 +213,7 @@ public final class RegistryBiomeEvent {
 		biomes.register(
 				"highlands_center",
 				new TFBiomeFinalPlateau(
-						new BiomeProperties("Highlands Center")
+						new BiomeProperties("Final Plateau")
 								.setTemperature(0.3F)
 								.setRainfall(0.2F)
 								.setBaseHeight(10.5F)


### PR DESCRIPTION
Totally not doing this so I can rename the page on the FTB Wiki from Highlands Center when the TF Wiki uses Final Plateau.