### PR TITLE
Partially resolve #655 Provide EntityTFPenguin with its own loot table.

### DIFF
--- a/src/main/java/twilightforest/entity/passive/EntityTFPenguin.java
+++ b/src/main/java/twilightforest/entity/passive/EntityTFPenguin.java
@@ -20,6 +20,8 @@ import net.minecraft.world.World;
 
 public class EntityTFPenguin extends EntityTFBird {
 
+	public static final ResourceLocation LOOT_TABLE = new ResourceLocation(TwilightForestMod.ID, "entities/penguin");
+
 	public EntityTFPenguin(World world) {
 		super(world);
 		this.setSize(0.5F, 0.9F);

--- a/src/main/java/twilightforest/entity/passive/EntityTFPenguin.java
+++ b/src/main/java/twilightforest/entity/passive/EntityTFPenguin.java
@@ -41,6 +41,11 @@ public class EntityTFPenguin extends EntityTFBird {
 	}
 
 	@Override
+	public ResourceLocation getLootTable() {
+		return LOOT_TABLE;
+	}
+
+	@Override
 	public EntityAnimal createChild(EntityAgeable entityanimal) {
 		return new EntityTFPenguin(world);
 	}

--- a/src/main/resources/assets/twilightforest/loot_tables/entities/penguin.json
+++ b/src/main/resources/assets/twilightforest/loot_tables/entities/penguin.json
@@ -1,0 +1,16 @@
+{
+  "pools": [
+    {
+      "name": "feather",
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "minecraft:feather",
+        "functions": [
+          { "function": "set_count", "count": { "min": 0, "max": 2 } },
+          { "function": "looting_enchant", "count": { "min": 0, "max": 1 } }
+        ]
+      }]
+    }
+  ]
+}


### PR DESCRIPTION
Partially resolves #655 by providing a default loot table (duplicated from the bird loot table) for EntityTFPenguin. 