### PR TITLE
Added config to block return portal when spawn_in_tf = true

### DIFF
--- a/src/main/java/twilightforest/NoPortalTFTeleporter.java
+++ b/src/main/java/twilightforest/NoPortalTFTeleporter.java
@@ -1,0 +1,33 @@
+package twilightforest;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.Teleporter;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+
+public class NoPortalTFTeleporter extends TFTeleporter {
+	
+	public static NoPortalTFTeleporter getTeleporterForDim(MinecraftServer server, int dim) {
+		WorldServer ws = server.getWorld(dim);
+
+		for (Teleporter t : ws.customTeleporters) {
+			if (t instanceof NoPortalTFTeleporter) {
+				return (NoPortalTFTeleporter) t;
+			}
+		}
+
+		NoPortalTFTeleporter tp = new NoPortalTFTeleporter(ws);
+		ws.customTeleporters.add(tp);
+		return tp;
+	}
+
+	private NoPortalTFTeleporter(WorldServer dest) {
+		super(dest);
+	}
+	
+	@Override
+	protected BlockPos makePortalAt(World world, BlockPos pos) {
+		return pos;
+	}
+}

--- a/src/main/java/twilightforest/TFConfig.java
+++ b/src/main/java/twilightforest/TFConfig.java
@@ -47,6 +47,10 @@ public class TFConfig {
 		@Config.LangKey(config + "spawn_in_tf")
 		@Config.Comment("If true, players spawning for the first time will spawn in the Twilight Forest.")
 		public boolean newPlayersSpawnInTF = false;
+		
+		@Config.LangKey(config + "spawn_return_portal")
+		@Config.Comment("If true and spawn_in_tf is true, players spawning into the Twilight Forest will spawn a portal next to them")
+		public boolean newPlayersSpawnReturnPortal = true;
 
 		@Config.LangKey(config + "skylight_forest")
 		@Config.RequiresWorldRestart

--- a/src/main/java/twilightforest/TFEventListener.java
+++ b/src/main/java/twilightforest/TFEventListener.java
@@ -725,11 +725,18 @@ public class TFEventListener {
 
 		// getBoolean returns false, if false or didn't exist
 		boolean shouldBanishPlayer = TFConfig.dimension.newPlayersSpawnInTF && !playerData.getBoolean(NBT_TAG_TWILIGHT);
+		boolean shouldSpawnReturnPortal = TFConfig.dimension.newPlayersSpawnReturnPortal;
 
 		playerData.setBoolean(NBT_TAG_TWILIGHT, true); // set true once player has spawned either way
 		tagCompound.setTag(EntityPlayer.PERSISTED_NBT_TAG, playerData); // commit
 
-		if (shouldBanishPlayer) BlockTFPortal.attemptSendPlayer(player, true); // See ya hate to be ya
+		if (shouldBanishPlayer) {
+			if (shouldSpawnReturnPortal) {
+				BlockTFPortal.attemptSendPlayer(player, true); // See ya hate to be ya
+			} else {
+				BlockTFPortal.attemptSendPlayer(player, true, false);
+			}
+		}
 	}
 
 	// Advancement Trigger

--- a/src/main/java/twilightforest/TFEventListener.java
+++ b/src/main/java/twilightforest/TFEventListener.java
@@ -730,13 +730,7 @@ public class TFEventListener {
 		playerData.setBoolean(NBT_TAG_TWILIGHT, true); // set true once player has spawned either way
 		tagCompound.setTag(EntityPlayer.PERSISTED_NBT_TAG, playerData); // commit
 
-		if (shouldBanishPlayer) {
-			if (shouldSpawnReturnPortal) {
-				BlockTFPortal.attemptSendPlayer(player, true); // See ya hate to be ya
-			} else {
-				BlockTFPortal.attemptSendPlayer(player, true, false);
-			}
-		}
+		if (shouldBanishPlayer)	BlockTFPortal.attemptSendPlayer(player, true, shouldSpawnReturnPortal); // See ya hate to be ya
 	}
 
 	// Advancement Trigger

--- a/src/main/java/twilightforest/TFTeleporter.java
+++ b/src/main/java/twilightforest/TFTeleporter.java
@@ -43,7 +43,7 @@ public class TFTeleporter extends Teleporter {
 		return tp;
 	}
 
-	private TFTeleporter(WorldServer dest) {
+	protected TFTeleporter(WorldServer dest) {
 		super(dest);
 	}
 
@@ -405,7 +405,7 @@ public class TFTeleporter extends Teleporter {
 		destinationCoordinateCache.put(ChunkPos.asLong(x, z), new PortalPosition(pos, world.getTotalWorldTime()));
 	}
 
-	private BlockPos makePortalAt(World world, BlockPos pos) {
+	protected BlockPos makePortalAt(World world, BlockPos pos) {
 
 		if (pos.getY() < 30) {
 			pos = new BlockPos(pos.getX(), 30, pos.getZ());

--- a/src/main/java/twilightforest/block/BlockTFPortal.java
+++ b/src/main/java/twilightforest/block/BlockTFPortal.java
@@ -29,6 +29,8 @@ import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.mutable.MutableInt;
+
+import twilightforest.NoPortalTFTeleporter;
 import twilightforest.TFConfig;
 import twilightforest.TFTeleporter;
 import twilightforest.TwilightForestMod;
@@ -235,6 +237,10 @@ public class BlockTFPortal extends BlockBreakable {
 	}
 
 	public static void attemptSendPlayer(Entity entity, boolean forcedEntry) {
+		attemptSendPlayer(entity, forcedEntry, true);
+	}
+	
+	public static void attemptSendPlayer(Entity entity, boolean forcedEntry, boolean shouldSpawnReturnPortal) {
 
 		if (entity.isDead || entity.world.isRemote) {
 			return;
@@ -252,8 +258,11 @@ public class BlockTFPortal extends BlockBreakable {
 		entity.timeUntilPortal = 10;
 
 		int destination = getDestination(entity);
-
-		entity.changeDimension(destination, TFTeleporter.getTeleporterForDim(entity.getServer(), destination));
+		if (shouldSpawnReturnPortal) {
+			entity.changeDimension(destination, TFTeleporter.getTeleporterForDim(entity.getServer(), destination));
+		} else {
+			entity.changeDimension(destination, NoPortalTFTeleporter.getTeleporterForDim(entity.getServer(), destination));
+		}
 
 		if (destination == TFConfig.dimension.dimensionID && entity instanceof EntityPlayerMP) {
 			EntityPlayerMP playerMP = (EntityPlayerMP) entity;


### PR DESCRIPTION
When spawn_in_tf is true and spawn_return_portal is false, players will be dropped into the twilight forest without a portal on first spawn.