### PR TITLE
Add Pages for Tower Devices

### DIFF
--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/categories/devices.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/categories/devices.json
@@ -1,0 +1,6 @@
+{
+  "name": "Devices and Mechanisms",
+  "description": "Technology in the Twilight Forest",
+  "icon": "twilightforest:tower_device:0",
+  "sortnum": 3500
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/anti-builder.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/anti-builder.json
@@ -1,0 +1,15 @@
+{
+  "name": "Anti-builder",
+  "icon": "twilightforest:tower_device:9",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/carminite",
+  "sortnum": 6240,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Anti-builder",
+      "item": "twilightforest:tower_device:9",
+      "text": "There is a strange aura emitted from this block, and it seems to be protecting anything that is within this bound. Any attempts to place a block in this field results in it being broken, and breaking anything augments a strange red-and-green block. There doesn't seem to be a switch to turn it off, but there must be a way."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/carminite_builder.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/carminite_builder.json
@@ -1,0 +1,15 @@
+{
+  "name": "Carminite Builder",
+  "icon": "twilightforest:tower_device:6",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/carminite",
+  "sortnum": 6230,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Carminite Builder",
+      "item": "twilightforest:tower_device:6",
+      "text": "This strange device will augment red transparent blocks when it receives a Redstone signal. Once triggered, the Carminite Builder will create a path and will build depending on where I am looking. This path is only temporary, and will need another Redstone signal to reactivate it."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/carminite_reactor.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/carminite_reactor.json
@@ -1,0 +1,18 @@
+{
+  "name": "Carminite Reactor",
+  "icon": "twilightforest:tower_device:12",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/carminite",
+  "sortnum": 6260,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Carminite Reactor",
+      "item": "twilightforest:tower_device:12",
+      "text": "I cannot seem to understand what this is for. It is a reactor of sorts, so I'd assume it would emit power, but all it does is idle. Perhaps it is the one that needs power?"
+    }, {
+      "type": "text",
+      "text": "Should I be in awe or afraid? If I can give this device enough Redstone power, the surrounding area turns into Gold and Diamond. I cannot describe it, but those blocks are fake, and the reactor implodes on me, releasing Carminite Ghastlings. Whether or not this may have been a failed experiment, I will never know."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/ghast_trap.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/ghast_trap.json
@@ -1,0 +1,18 @@
+{
+  "name": "Ghast Trap",
+  "icon": "twilightforest:tower_device:10",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/carminite",
+  "sortnum": 6250,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Ghast Trap",
+      "item": "twilightforest:tower_device:10",
+      "text": "Namesake, it appears that this device's sole purpose is to trap Ghasts. It seems giving this thing a Redstone signal does nothing, perhaps it needs some sort of power source?"
+    }, {
+      "type": "text",
+      "text": "It is just what I'm after! If I can kill enough of these weak Ghastlings around one of these traps, it will gain the energy from those killed. There is a quiet pinging noise that emanates from this device, and if it is loud enough, I can trigger a Redstone signal to execute this device and wrench Ghasts from the sky, sucking up their life, too."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/locked_vanishing_block.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/locked_vanishing_block.json
@@ -1,0 +1,18 @@
+{
+  "name": "Locked Vanishing Block",
+  "icon": "twilightforest:tower_device:4",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/carminite",
+  "sortnum": 6220,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Locked Vanishing Block",
+      "item": "twilightforest:tower_device:4",
+      "text": "There's something not right with this thing. No matter what I do to it, nothing happens to it, and neither do the connected Vanishing Blocks. I noticed this strange shape in the center of this device, perhaps it needs a key of some sort?"
+    }, {
+      "type": "text",
+      "text": "Of course, these devices are like locks to doors. If I give one of these a Tower Key, they will be unlocked, and thus interacting with one will cause them to vanish before me, and allow neighboring Vanishing Blocks to disappear."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/reappearing_block.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/reappearing_block.json
@@ -1,0 +1,15 @@
+{
+  "name": "Reappearing Block",
+  "icon": "twilightforest:tower_device:0",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/carminite",
+  "sortnum": 6200,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Reappearing Block",
+      "item": "twilightforest:tower_device:0",
+      "text": "There appears to be something compelling and intriguing about this device. When I touch this block or give it a Redstone signal, it vanishes before my eyes. It seems to come back after a determined amount of time, but I guess I'll never understand why."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/vanishing_block.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/vanishing_block.json
@@ -1,0 +1,15 @@
+{
+  "name": "Vanishing Block",
+  "icon": "twilightforest:tower_device:2",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/carminite",
+  "sortnum": 6210,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Vanishing Block",
+      "item": "twilightforest:tower_device:2",
+      "text": "This is more peculiar than I anticipated. When I touch or give this block a Redstone signal, it vanishes before my eyes. Even after waiting, it never comes back, so what purpose can it serve for security?"
+    }
+  ]
+}


### PR DESCRIPTION
This PR contains the contents for Reappearing Block, Vanishing Block, Locked Vanishing Block, Carminite Builder, Anti-builder, Ghast Trap, and Carminite Reactor. These pages are categorised under a new category: Devices, which can be used to document all blocks with a function. The following currently happens:
- The category does not have a parent category. Should this be put under Treasures, or a new category containing all blocks and items?
- The pages are unlocked when the player obtains Carminite. This is because Locked Vanishing Block, Carminite Builder, Anti-builder, and Ghast Trap cannot be obtained legitimately. Should this be changed to when the player get the advancement "Carminite Acclimation", and Reappearing Block gets a new page when the aforementioned advancement is locked, but they have the advancement Bring Out Your Dead?
- Regarding pages, all of them are unlocked initially (if they have a second page). The following were some ideas I had:
  - (If the previous point goes through) Reappearing Block's entry will change if the advancement Carminite Acclimation is obtained. Or, when the block is successfully opened.
  - Vanishing Block's entry will unlock if the block is successfully opened.
  - Locked Vanishing Block's entry will change if a Tower Key is used on it to become Unlocked Vanishing Block.
  - Carminite Builder's entry will unlock if the block receives a Redstone signal and starts building.
  - Anti-builder's entry will unlock if Reappearing Block's full unlock criteria is met, or if the player breaks an Anti-built block.
  - Ghast Trap's entry will change if the advancement Something Strange in Towerwood is met.
  - Carminite Reactor's entry will change once it explodes.
- Currently, this PR only has Tower Devices, however I can move the Uncrafting Table here if needed.

I am up to suggestions to altering the text entries or anything else.