### PR TITLE
Add pages for Smoking Blocks and Fire Jets

### DIFF
--- a/src/main/resources/assets/twilightforest/advancements/alt/treasures/encased_fire_jet.json
+++ b/src/main/resources/assets/twilightforest/advancements/alt/treasures/encased_fire_jet.json
@@ -1,0 +1,11 @@
+{
+  "parent": "twilightforest:alt/root",
+  "criteria": {
+    "ingredient":  { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "item": "twilightforest:fire_jet",     "data": 3 }]}},
+    "ingredient2": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "item": "twilightforest:tower_wood",   "data": 1 }]}},
+    "encased_jet": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "item": "twilightforest:fire_jet",     "data": 6 }]}}
+  },
+  "requirements": [
+    [ "ingredient", "ingredient2", "encased_jet" ]
+  ]
+}

--- a/src/main/resources/assets/twilightforest/advancements/alt/treasures/encased_smoker.json
+++ b/src/main/resources/assets/twilightforest/advancements/alt/treasures/encased_smoker.json
@@ -1,0 +1,11 @@
+{
+  "parent": "twilightforest:alt/root",
+  "criteria": {
+    "ingredient":  { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "item": "twilightforest:fire_jet",     "data": 0 }]}},
+    "ingredient2": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "item": "twilightforest:tower_wood",   "data": 1 }]}},
+    "encased_jet": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "item": "twilightforest:fire_jet",     "data": 1 }]}}
+  },
+  "requirements": [
+    [ "ingredient", "ingredient2", "encased_jet" ]
+  ]
+}

--- a/src/main/resources/assets/twilightforest/advancements/alt/treasures/fire_jet.json
+++ b/src/main/resources/assets/twilightforest/advancements/alt/treasures/fire_jet.json
@@ -5,6 +5,6 @@
     "fire_swamp": { "trigger": "twilightforest:has_advancement", "conditions": { "advancement": "twilightforest:alt/biomes/fire_swamp"       }}
   },
   "requirements": [
-    [ "fire_jst", "fire_swamp" ]
+    [ "fire_jet", "fire_swamp" ]
   ]
 }

--- a/src/main/resources/assets/twilightforest/advancements/alt/treasures/fire_jet.json
+++ b/src/main/resources/assets/twilightforest/advancements/alt/treasures/fire_jet.json
@@ -1,0 +1,10 @@
+{
+  "parent": "twilightforest:alt/root",
+  "criteria": {
+    "fire_jet":   { "trigger": "minecraft:inventory_changed",    "conditions": { "items": [{ "item": "twilightforest:fire_jet", "data": 3 }] }},
+    "fire_swamp": { "trigger": "twilightforest:has_advancement", "conditions": { "advancement": "twilightforest:alt/biomes/fire_swamp"       }}
+  },
+  "requirements": [
+    [ "fire_jst", "fire_swamp" ]
+  ]
+}

--- a/src/main/resources/assets/twilightforest/advancements/alt/treasures/smoking_block.json
+++ b/src/main/resources/assets/twilightforest/advancements/alt/treasures/smoking_block.json
@@ -1,0 +1,10 @@
+{
+  "parent": "twilightforest:alt/root",
+  "criteria": {
+    "smoking_block": { "trigger": "minecraft:inventory_changed",    "conditions": { "items": [{ "item": "twilightforest:fire_jet", "data": 0 }] }},
+    "fire_swamp":    { "trigger": "twilightforest:has_advancement", "conditions": { "advancement": "twilightforest:alt/biomes/fire_swamp"       }}
+  },
+  "requirements": [
+    [ "smoking_block", "fire_swamp" ]
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/encased_fire_jet.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/encased_fire_jet.json
@@ -1,0 +1,15 @@
+{
+  "name": "Encased Fire Jet",
+  "icon": "twilightforest:fire_jet:6",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/encased_fire_jet",
+  "sortnum": 5060,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Encased Fire Jet",
+      "item": "twilightforest:fire_jet:6",
+      "text": "By taking a Fire Jet, and a bit of technical genius, I can create a Fire Jet that is self-sustaining and can fire with the press of a button, or a bit of Redstone signal. Though, a minor flaw with this device seems to be that it needs to warm up before it fires, so I must time the signals right."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/encased_smoker.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/encased_smoker.json
@@ -1,0 +1,15 @@
+{
+  "name": "Encased Smoker",
+  "icon": "twilightforest:fire_jet:1",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/encased_smoker",
+  "sortnum": 5060,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Encased Smoker",
+      "item": "twilightforest:fire_jet:1",
+      "text": "Smoking Blocks will always emit smoke, but this is rather inconvenient for me. By wiring up a Smoking Block, I can create a device that will only emit smoke when I activate it. Now I must consider the practicality of such device."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/fire_jet.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/fire_jet.json
@@ -1,0 +1,15 @@
+{
+  "name": "Fire Jet",
+  "icon": "twilightforest:fire_jet:3",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/smoking_block",
+  "sortnum": 5050,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Fire Jet",
+      "item": "twilightforest:fire_jet:3",
+      "text": "Volatile jets that will shoot streams of fire at random. I have to be careful around these, for they don't seem to be triggered by anything. For some reason, they stop erupting when there's no Lava beneath it, perhaps that is their secret?"
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/fire_jet.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/fire_jet.json
@@ -2,7 +2,7 @@
   "name": "Fire Jet",
   "icon": "twilightforest:fire_jet:3",
   "category": "devices",
-  "advancement": "twilightforest:alt/treasures/smoking_block",
+  "advancement": "twilightforest:alt/treasures/fire_jet",
   "sortnum": 5050,
   "pages": [
     {

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/smoking_block.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/smoking_block.json
@@ -2,7 +2,7 @@
   "name": "Smoking Block",
   "icon": "twilightforest:fire_jet:0",
   "category": "devices",
-  "advancement": "twilightforest:alt/treasures/fire_jet",
+  "advancement": "twilightforest:alt/treasures/smoking_block",
   "sortnum": 5050,
   "pages": [
     {

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/smoking_block.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/devices/smoking_block.json
@@ -1,0 +1,15 @@
+{
+  "name": "Smoking Block",
+  "icon": "twilightforest:fire_jet:0",
+  "category": "devices",
+  "advancement": "twilightforest:alt/treasures/fire_jet",
+  "sortnum": 5050,
+  "pages": [
+    {
+      "type": "spotlight",
+      "title": "Smoking Block",
+      "item": "twilightforest:fire_jet:0",
+      "text": "These seem to be relatively safe to stand over. The soles of my feet aren't blistering and my skin isn't burning, but on the other hand it isn't pleasant to breathe in. This thing does seem to sustain itself, no heat needed; I wonder if that would be useful?"
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/sortnum_reference.txt
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/sortnum_reference.txt
@@ -117,6 +117,14 @@ mazebreaker_pickaxe.json
 5040
 minoshroom.json
 
+5050
+smoking_block.json
+fire_jet.json
+
+5060
+encased_smoking_block.json
+encased_fire_jet.json
+
 5100
 hydra_lair.json
 


### PR DESCRIPTION
This adds pages for Smoking Block, Fire Jet, Encased Smoker, and Encased Fire Jet. Also includes advancements for them. These pages don't have an additional page for them since I don't see fit for additional criteria.
Sortnum reference file updated as required.