### PR TITLE
Replace umlaut-o with plain o. Resolves build/compilation issues.

### DIFF
--- a/src/main/java/twilightforest/advancements/BlockPredicate.java
+++ b/src/main/java/twilightforest/advancements/BlockPredicate.java
@@ -70,12 +70,12 @@ public class BlockPredicate {
             String value,
             String comparisonType) {
 
-        Optional<T> schrödingersVar = key.parseValue(value);
+        Optional<T> schrodingersVar = key.parseValue(value);
         PropertyPredicate.ComparisonType predicateComparator = PropertyPredicate.ComparisonType.get(comparisonType);
 
-        if (predicateComparator == null || !schrödingersVar.isPresent()) return; // Skip
+        if (predicateComparator == null || !schrodingersVar.isPresent()) return; // Skip
 
-        predicateSet.add(new PropertyPredicate<>(key, schrödingersVar.get(), predicateComparator));
+        predicateSet.add(new PropertyPredicate<>(key, schrodingersVar.get(), predicateComparator));
     }
 
     public boolean test(World world, BlockPos pos) {


### PR DESCRIPTION
There is literally no reason why I should be getting an error trying to
build the project, rebuild the project or reload classes. While the
Gradle settings have it compiling correctly, for whatever reason I'm
unable to build or rebuild the project/reload classes after launching
because of this umlaut.

I have changed my own encoding settings multiple times to no avail,
as they always seem to reset when switching between projects. I end
up spending more time fixing my build environment than doing actual
coding.

Having to change the actual source code and then make sure I don't
accidentally include it in any commits is a little bit frustrating.