### PR TITLE
IMC and config support for hollow hill ore stalactites

### DIFF
--- a/src/main/java/twilightforest/IMCHandler.java
+++ b/src/main/java/twilightforest/IMCHandler.java
@@ -1,6 +1,9 @@
 package twilightforest;
 
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -9,16 +12,20 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTUtil;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
+import twilightforest.world.feature.TFGenCaveStalactite;
+
+import java.util.function.Consumer;
 
 public class IMCHandler {
 	private static final ImmutableSet.Builder<IBlockState> BLACKLIST_BUILDER = ImmutableSet.builder();
 	private static final ImmutableList.Builder<IBlockState> ORE_BLOCKS_BUILDER = ImmutableList.builder();
 	private static final ImmutableList.Builder<ItemStack> LOADING_ICONS_BUILDER = ImmutableList.builder();
 	private static final ImmutableMultimap.Builder<IBlockState, IBlockState> CRUMBLE_BLOCKS_BUILDER = ImmutableMultimap.builder();
+	private static final ImmutableMultimap.Builder<Integer, TFGenCaveStalactite.StalactiteEntry> STALACTITE_BUILDER = ImmutableMultimap.builder();
 
 	/**
 	 IMC NBT Format: You can send all of your requests as one big NBT list rather than needing to shotgun a ton of tiny NBT messages.
-
+	 <pre>
 	 root:
 		 • "Blacklist"                               - NBTTagList     : List of blockstates to blacklist from blockbreaking (antibuilders, naga, hydra, etc)
 			 • List Entry                            - NBTTagCompound : An IBlockState
@@ -26,13 +33,19 @@ public class IMCHandler {
 				 • "Properties"                      - NBTTagCompound : Blockstate Properties
 					 • [String Property Key]         - String         : Key is nameable to a property key, and the string value attached to it is value to property.
 
-		 • "Ore_Blocks" [NYI]                        - NBTTagList     : List of blockstates to add to Hollow Hills and Ore Magnets - May change this to a function in the future
-			 • List Entry                            - NBTTagCompound : An IBlockState
+		 • "Ore_Blocks"                              - NBTTagList     : List of blockstates to add to Hollow Hills and Ore Magnets - May change this to a function in the future
+			 • List Entry                            - NBTTagCompound : An IBlockState and/or an oredict name
 				 • "Name"                            - String         : Resource location of block. Is not allowed to be Air.
 				 • "Properties"                      - NBTTagCompound : Blockstate Properties
 					 • [String Property Key]         - String         : Key is nameable to a property key, and the string value attached to it is value to property.
+	 			 • "Stalactite_Settings"             - NBTTagCompound : Settings for stalactite generation, exclude if only used for Ore Magnets. May be empty for all default values.
+	 			 	 • "Weight"                      - Integer        : Ore weight, decides how often the ore generates. Defaults to 15.
+	 				 • "Hill_Size"                   - Integer        : Minimum hill size for the ore stalactite to generate. 1-small, 2-medium, 3-large. Defaults to 3.
+	 				 • "Size"                        - Float          : Decides the maximum length of the stalactite relative to the space between hill floor and ceiling. Defaults to 0.7.
+	 				 • "Max_Length"                  - Integer        : Maximum length of a stalactite in blocks. Defaults to 8.
+	 				 • "Min_Height"                  - Integer        : Minimum space between the hill floor and the stalactite to let it generate. Defaults to 1.
 
-		 • "Crumbling"                               - NBTTagList     : List of blockstates to add to hollow hills - May chance this to a function in the future
+		 • "Crumbling"                               - NBTTagList     : List of blockstates to add to crumble horn crumbling - May change this to a function in the future
 			 • List Entry                            - NBTTagCompound : An IBlockState
 				 • "Name"                            - String         : Resource location of block. Is not allowed to be Air.
 				 • "Properties"                      - NBTTagCompound : Blockstate Properties
@@ -41,6 +54,7 @@ public class IMCHandler {
 						 • "Name"                    - String         : Resource location of block. Can be Air.
 						 • "Properties"              - NBTTagCompound : Blockstate Properties
 							 • [String Property Key] - String         : Key is nameable to a property key, and the string value attached to it is value to property.
+	 </pre>
 	 */
 
 	public static void onIMC(FMLInterModComms.IMCEvent event) {
@@ -48,9 +62,9 @@ public class IMCHandler {
 			if (message.isNBTMessage()) {
 				NBTTagCompound imcCompound = message.getNBTValue();
 
-				deserializeBlockstatesFromTagList(imcCompound.getTagList("Blacklist" , Constants.NBT.TAG_COMPOUND), BLACKLIST_BUILDER );
-				deserializeBlockstatesFromTagList(imcCompound.getTagList("Ore_Blocks", Constants.NBT.TAG_COMPOUND), ORE_BLOCKS_BUILDER );
-				deserializeBlockstatesFromTagList(imcCompound.getTagList("Crumbling" , Constants.NBT.TAG_COMPOUND), CRUMBLE_BLOCKS_BUILDER );
+				deserializeBlockstatesFromTagList(imcCompound.getTagList("Blacklist",  Constants.NBT.TAG_COMPOUND), BLACKLIST_BUILDER);
+				readFromTagList(imcCompound.getTagList("Ore_Blocks", Constants.NBT.TAG_COMPOUND), IMCHandler::handleOre);
+				readFromTagList(imcCompound.getTagList("Crumbling",  Constants.NBT.TAG_COMPOUND), IMCHandler::handleCrumble);
 			}
 
 			if (message.isItemStackMessage() && message.key.equals("Loading_Icon")) {
@@ -59,20 +73,9 @@ public class IMCHandler {
 		}
 	}
 
-	private static void deserializeBlockstatesFromTagList(NBTTagList list, ImmutableMultimap.Builder<IBlockState, IBlockState> builder) {
+	private static void readFromTagList(NBTTagList list, Consumer<NBTTagCompound> consumer) {
 		for (int blockAt = 0; blockAt < list.tagCount(); blockAt++) {
-			NBTTagCompound main = list.getCompoundTagAt(blockAt);
-			IBlockState key = NBTUtil.readBlockState(main);
-
-			if (key.getBlock() != Blocks.AIR) {
-				NBTTagList crumbles = main.getTagList("Crumbling", Constants.NBT.TAG_COMPOUND);
-
-				for (int crumble = 0; crumble < crumbles.tagCount(); crumble++) {
-					IBlockState value = NBTUtil.readBlockState(crumbles.getCompoundTagAt(crumble));
-
-					builder.put(key, value);
-				}
-			}
+			consumer.accept(list.getCompoundTagAt(blockAt));
 		}
 	}
 
@@ -82,6 +85,38 @@ public class IMCHandler {
 
 			if (state.getBlock() != Blocks.AIR)
 				builder.add(state);
+		}
+	}
+
+	private static void handleCrumble(NBTTagCompound nbt) {
+		IBlockState key = NBTUtil.readBlockState(nbt);
+
+		if (key.getBlock() != Blocks.AIR) {
+			NBTTagList crumbles = nbt.getTagList("Crumbling", Constants.NBT.TAG_COMPOUND);
+
+			for (int crumble = 0; crumble < crumbles.tagCount(); crumble++) {
+				IBlockState value = NBTUtil.readBlockState(crumbles.getCompoundTagAt(crumble));
+
+				CRUMBLE_BLOCKS_BUILDER.put(key, value);
+			}
+		}
+	}
+
+	private static void handleOre(NBTTagCompound nbt) {
+		IBlockState nbtState = NBTUtil.readBlockState(nbt);
+
+		if (nbtState.getBlock() != Blocks.AIR) {
+			ORE_BLOCKS_BUILDER.add(nbtState);
+			
+			if (nbt.hasKey("Stalactite_Settings")) {
+				NBTTagCompound settings = nbt.getCompoundTag("Stalactite_Settings");
+				int weight    = settings.hasKey("Weight")     ? settings.getInteger("Weight")     : 15;
+				int hillSize  = settings.hasKey("Hill_Size")  ? settings.getInteger("Hill_Size")  : 3;
+				float size    = settings.hasKey("Size")       ? settings.getFloat("Size")         : 0.7f;
+				int maxLength = settings.hasKey("Max_Length") ? settings.getInteger("Max_Length") : 8;
+				int minHeight = settings.hasKey("Min_Height") ? settings.getInteger("Min_Height") : 1;
+				STALACTITE_BUILDER.put(hillSize, new TFGenCaveStalactite.StalactiteEntry(nbtState, size, maxLength, minHeight, weight));
+			}
 		}
 	}
 
@@ -99,5 +134,9 @@ public class IMCHandler {
 
 	public static ImmutableMultimap<IBlockState, IBlockState> getCrumblingBlocks() {
 		return CRUMBLE_BLOCKS_BUILDER.build();
+	}
+
+	public static ImmutableMultimap<Integer, TFGenCaveStalactite.StalactiteEntry> getStalactites() {
+		return STALACTITE_BUILDER.build();
 	}
 }

--- a/src/main/java/twilightforest/TFConfig.java
+++ b/src/main/java/twilightforest/TFConfig.java
@@ -17,6 +17,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.oredict.OreDictionary;
 import twilightforest.world.WorldProviderTwilightForest;
+import twilightforest.world.feature.TFGenCaveStalactite;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -114,6 +115,67 @@ public class TFConfig {
 			@Config.RequiresMcRestart
 			@Config.RangeInt(min = 0)
 			public int druidHutWeight = 10;
+		}
+
+		@Config.LangKey(config + "hollow_hill_stalactites")
+		@Config.Comment("Defines custom stalactites generated in hollow hills." +
+				"\nFormat is \"modid:block<:meta> size maxLength minHeight weight\", where the properties are:" +
+				"\nSize - the maximum length of the stalactite relative to the space between hill floor and ceiling," +
+				"\nMax length - maximum length of a stalactite in blocks," +
+				"\nMin height - minimum space between the hill floor and the stalactite to let it generate," +
+				"\nWeight - how often it generates." +
+				"\n\nFor example: \"minecraft:iron_ore 0.7 8 1 24\" would add a stalactite equal to the default iron ore stalactite.")
+		@Config.RequiresMcRestart
+		public HollowHillStalactites hollowHillStalactites = new HollowHillStalactites();
+
+		public static class HollowHillStalactites {
+			@Config.LangKey(config + "large_hill")
+			@Config.RequiresMcRestart
+			@Config.Comment("Blocks generating as stalactites in large hills only")
+			public String[] largeHill = {};
+
+			@Config.LangKey(config + "medium_hill")
+			@Config.RequiresMcRestart
+			@Config.Comment("Blocks generating as stalactites in medium and large hills")
+			public String[] mediumHill = {};
+
+			@Config.LangKey(config + "small_hill")
+			@Config.RequiresMcRestart
+			@Config.Comment("Blocks generating as stalactites in all hills")
+			public String[] smallHill = {};
+
+			@Config.LangKey(config + "stalactite_config_only")
+			@Config.RequiresMcRestart
+			@Config.Comment("If true, default stalactites and stalactites defined by other mods will not be used.")
+			public boolean useConfigOnly = false;
+
+			public void load() {
+				registerHill(smallHill, 1);
+				registerHill(mediumHill, 2);
+				registerHill(largeHill, 3);
+			}
+
+			private void registerHill(String[] definitions, int tier) {
+				for (String definition : definitions) {
+					String[] split = definition.split(" ");
+					if (split.length != 5) {
+						TwilightForestMod.LOGGER.warn("Invalid hollow hill stalactite definition: {}", definition);
+						continue;
+					}
+					parseBlockState(split[0]).ifPresent(blockstate -> {
+						try {
+							TFGenCaveStalactite.addStalactite(tier, blockstate,
+											Float.parseFloat(split[1]),
+											Integer.parseInt(split[2]),
+											Integer.parseInt(split[3]),
+											Integer.parseInt(split[4])
+							);
+						} catch (NumberFormatException e) {
+							TwilightForestMod.LOGGER.warn("Invalid hollow hill stalactite definition: {}", definition);
+						}
+					});
+				}
+			}
 		}
 	}
 

--- a/src/main/java/twilightforest/TwilightForestMod.java
+++ b/src/main/java/twilightforest/TwilightForestMod.java
@@ -28,6 +28,7 @@ import twilightforest.structures.start.StructureStartNothing;
 import twilightforest.tileentity.*;
 import twilightforest.tileentity.spawner.*;
 import twilightforest.world.WorldProviderTwilightForest;
+import twilightforest.world.feature.TFGenCaveStalactite;
 
 @Mod( modid = TwilightForestMod.ID,
 		name = TwilightForestMod.NAME,
@@ -154,6 +155,7 @@ public class TwilightForestMod {
 		}
 
 		TFConfig.build();
+		TFGenCaveStalactite.loadStalactites();
 	}
 
 	@EventHandler

--- a/src/main/resources/assets/twilightforest/lang/en_us.lang
+++ b/src/main/resources/assets/twilightforest/lang/en_us.lang
@@ -665,6 +665,17 @@ twilightforest.config.fallen_hollow_log_weight=Fallen Hollow Log weight
 twilightforest.config.fallen_small_log_weight=Fallen Small Log weight
 twilightforest.config.druid_hut_weight=Druid Hut weight
 
+twilightforest.config.hollow_hill_stalactites=Custom Hollow Hill Stalactites
+twilightforest.config.hollow_hill_stalactites.tooltip=Defines custom stalactites generated in hollow hills.\nFormat is \"modid:block<:meta> size maxLength minHeight weight\", where the properties are:\nSize - the maximum length of the stalactite relative to the space between hill floor and ceiling,\nMax length - maximum length of a stalactite in blocks,\nMin height - minimum space between the hill floor and the stalactite to let it generate,\nWeight - how often it generates.\n\nFor example: \"minecraft:iron_ore 0.7 8 1 24\" would add a stalactite equal to the default iron ore stalactite.
+twilightforest.config.large_hill=Large Hills
+twilightforest.config.large_hill.tooltip=Blocks generating as stalactites in large hills only.
+twilightforest.config.medium_hill=Medium and Large Hills
+twilightforest.config.medium_hill.tooltip=Blocks generating as stalactites in medium and large hills.
+twilightforest.config.small_hill=All Hills
+twilightforest.config.small_hill.tooltip=Blocks generating as stalactites in all hills.
+twilightforest.config.stalactite_config_only=Only Use the Stalactite Config
+twilightforest.config.stalactite_config_only.tooltip=If true, default stalactites and stalactites defined by other mods will not be used.
+
 twilightforest.config.compat=Compatibility
 twilightforest.config.compat.tooltip=Should TF Compatibility load? Turn off if TF's Compatibility is causing crashes or if not desired.
 


### PR DESCRIPTION
I had this mostly ready for a few weeks now but got either sidetracked or busy... Also, this probably could've been done a bit better.

So, this PR adds IMC and a config for hollow hill stalactites, for modders who want integration and for modpack authors who want their own ore additions, as well as changes the hollow hill ore stalactite selection to a weighted entry list. 

IMC accepts either just a state, just an oredict entry, or both. If an oredict entry is defined, it will only use the first sent entry with that oredict, and will either use the provided state or the first found state. All the found states are also added to the ore block list, which I guess is planned to be used with the magnet.

I tested the worldgen with both the IMC and the config and both work as expected.

Edit: resolves #499.