### PR TITLE
Fix FieryPick particle side assumption

### DIFF
--- a/src/main/java/twilightforest/item/ItemTFFieryPick.java
+++ b/src/main/java/twilightforest/item/ItemTFFieryPick.java
@@ -88,7 +88,9 @@ public class ItemTFFieryPick extends ItemPickaxe implements ModelRegisterCallbac
 		boolean result = super.hitEntity(stack, target, attacker);
 
 		if (result && !target.isImmuneToFire()) {
-			spawnParticles((WorldServer) target.world, target.posX, target.posY, target.posZ);
+			if (target.world instanceof WorldServer) {
+				spawnParticles((WorldServer) target.world, target.posX, target.posY, target.posZ);
+			}
 			target.setFire(15);
 		}
 


### PR DESCRIPTION
If you hit someone with a fiery pick, it'll crash your client trying to cast the world to a `WorldServer`.