### PR TITLE
Reduce the amount of CPU time spent in TFFeature

### DIFF
--- a/src/main/java/twilightforest/TFFeature.java
+++ b/src/main/java/twilightforest/TFFeature.java
@@ -716,11 +716,17 @@ public enum TFFeature {
 	 * that feature relative to the current chunk block coordinate system.
 	 */
 	public static TFFeature getNearestFeature(int cx, int cz, World world, @Nullable IntPair center) {
-		for (int rad = 1; rad <= maxSize; rad++) {
-			for (int x = -rad; x <= rad; x++) {
-				for (int z = -rad; z <= rad; z++) {
+		for (int ring = 1; ring <= maxSize; ring++) {
+			for (int x = -ring; x <= ring; x++) {
+				for (int z = -ring; z <= ring; z++) {
+					// Do not re-iterate values outside our ring
+					if (ring > 1 && (Math.abs(x) != ring || Math.abs(z) != ring)) {
+						continue;
+					}
+
 					TFFeature directlyAt = getFeatureDirectlyAt(x + cx, z + cz, world);
-					if (directlyAt.size == rad) {
+
+					if (directlyAt.size == ring) {
 						if (center != null) {
 							center.x = (x << 4) + 8;
 							center.z = (z << 4) + 8;
@@ -730,6 +736,7 @@ public enum TFFeature {
 				}
 			}
 		}
+
 		return NOTHING;
 	}
 

--- a/src/main/java/twilightforest/world/ChunkGeneratorTFBase.java
+++ b/src/main/java/twilightforest/world/ChunkGeneratorTFBase.java
@@ -103,8 +103,12 @@ public abstract class ChunkGeneratorTFBase implements IChunkGenerator {
 	}
 
 	protected final void generateFeatures(int x, int z, ChunkPrimer primer) {
-		for (MapGenTFMajorFeature generator : featureGenerators.values()) {
-			generator.generate(world, x, z, primer);
+		TFFeature feature = TFFeature.getFeatureDirectlyAt(x, z, this.world);
+
+		MapGenTFMajorFeature gen = featureGenerators.get(feature);
+
+		if (gen != null) {
+			gen.generate(world, x, z, primer);
 		}
 	}
 

--- a/src/main/java/twilightforest/world/ChunkGeneratorTwilightForest.java
+++ b/src/main/java/twilightforest/world/ChunkGeneratorTwilightForest.java
@@ -147,6 +147,9 @@ public class ChunkGeneratorTwilightForest extends ChunkGeneratorTFBase {
 			}
 		}
 
+		IntPair nearCenter = new IntPair();
+		TFFeature nearFeature = TFFeature.getNearestFeature(chunkX, chunkZ, world, nearCenter);
+
 		for (int z = 0; z < 16; z++) {
 			for (int x = 0; x < 16; x++) {
 
@@ -166,9 +169,6 @@ public class ChunkGeneratorTwilightForest extends ChunkGeneratorTFBase {
 				thickness -= 4;
 
 				//int thickness = thicks[qz + (qz) * 5];
-
-				IntPair nearCenter = new IntPair();
-				TFFeature nearFeature = TFFeature.getNearestFeature(chunkX, chunkZ, world, nearCenter);
 
 				// make sure we're not too close to the tower
 				if (nearFeature == TFFeature.DARK_TOWER) {


### PR DESCRIPTION
This commit makes three optimizations to reduce the amount of CPU time spent fetching the features for chunks. Before this change, around 5% of the time spent generating chunks was spent in TFFeature. With these changes, that time is reduced to almost zero. While this doesn't provide a massive boost to generation times, it is non-insignificant.

- `ChunkGeneratorTwilightForest#addDarkForestCanopy2` has been modified to only fetch the TFFeature once for the entire chunk instead of for every chunk column.
- `ChunkGeneratorTFBase` no longer attempts to generate all map generation features for each chunk. The TFFeature for the chunk is queried once and the appropriate feature generator is looked up from the generators map only once.
- `TFFeature#getNearestFeature` no longer iterates over the same area multiple times for each structure size. This reduces the worst-case iteration count from 30 to only 16 without changing behaviour.
