### PR TITLE
Improve terrain generation times slightly

### DIFF
--- a/src/main/java/twilightforest/biomes/TFBiomeBase.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeBase.java
@@ -143,9 +143,11 @@ public class TFBiomeBase extends Biome {
 				if (iblockstate2.getBlock() == Blocks.AIR) {
 					// j = -1; TF - commented out? todo 1.9
 				} else if (iblockstate2.getBlock() == Blocks.STONE) {
+					IBlockState finalState = STONE;
+
 					// TF - Replace stone
 					if (stoneReplacement != null) {
-						primer.setBlockState(i1, j1, l, stoneReplacement);
+						finalState = stoneReplacement;
 					}
 
 					if (j == -1) {
@@ -169,13 +171,17 @@ public class TFBiomeBase extends Biome {
 						j = k;
 
 						if (j1 >= i - 1) {
-							primer.setBlockState(i1, j1, l, iblockstate);
+							finalState = iblockstate;
 						} else if (j1 < i - 7 - k) {
 							iblockstate = AIR;
 							iblockstate1 = STONE;
-							primer.setBlockState(i1, j1, l, GRAVEL);
+							finalState = GRAVEL;
 						} else {
-							primer.setBlockState(i1, j1, l, iblockstate1);
+							finalState = iblockstate1;
+						}
+
+						if (finalState != iblockstate2) {
+							primer.setBlockState(i1, j1, l, finalState);
 						}
 					} else if (j > 0) {
 						--j;

--- a/src/main/java/twilightforest/world/ChunkBitArray.java
+++ b/src/main/java/twilightforest/world/ChunkBitArray.java
@@ -1,0 +1,28 @@
+package twilightforest.world;
+
+public class ChunkBitArray {
+    private static final int CHUNK_SIZE = (16 * 256 * 16);
+    private static final int BITS_PER_WORD = 6;
+
+    private final long[] words = new long[CHUNK_SIZE >> 3];
+
+    public void set(int index) {
+        this.words[index >> BITS_PER_WORD] |= (1L << index);
+    }
+
+    public void set(int index, boolean value) {
+        if (value) {
+            this.set(index);
+        } else {
+            this.clear(index);
+        }
+    }
+
+    public void clear(int index) {
+        this.words[index >> BITS_PER_WORD] &= ~(1L << index);
+    }
+
+    public boolean get(int index) {
+        return (this.words[index >> BITS_PER_WORD] & (1L << index)) != 0;
+    }
+}

--- a/src/main/java/twilightforest/world/ChunkGeneratorTFBase.java
+++ b/src/main/java/twilightforest/world/ChunkGeneratorTFBase.java
@@ -24,7 +24,6 @@ import twilightforest.block.TFBlocks;
 import twilightforest.util.IntPair;
 
 import javax.annotation.Nullable;
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -125,7 +124,7 @@ public abstract class ChunkGeneratorTFBase implements IChunkGenerator {
 
 	// note: ChunkPrimer changed to a BitSet marking 'solid' blocks
 	// this allows for some post-processing before populating the primer
-	protected final void setBlocksInChunk(int x, int z, BitSet data) {
+	protected final void setBlocksInChunk(int x, int z, ChunkBitArray data) {
 
 		byte seaLevel = 63;
 		this.biomesForGeneration = this.world.getBiomeProvider().getBiomesForGeneration(this.biomesForGeneration, x * 4 - 2, z * 4 - 2, 10, 10);
@@ -290,7 +289,7 @@ public abstract class ChunkGeneratorTFBase implements IChunkGenerator {
 	/**
 	 * Crush the terrain to half the height
 	 */
-	protected final void squishTerrain(BitSet data) {
+	protected final void squishTerrain(ChunkBitArray data) {
 		int squishHeight = TFWorld.MAXHEIGHT / 2;
 		for (int x = 0; x < 16; x++) {
 			for (int z = 0; z < 16; z++) {
@@ -304,7 +303,7 @@ public abstract class ChunkGeneratorTFBase implements IChunkGenerator {
 		}
 	}
 
-	protected abstract void initPrimer(ChunkPrimer primer, BitSet data);
+	protected abstract void initPrimer(ChunkPrimer primer, ChunkBitArray data);
 
 	// [VanillaCopy] Exact, ChunkGeneratorOverworld.replaceBiomeBlocks
 	public void replaceBiomeBlocks(int x, int z, ChunkPrimer primer, Biome[] biomesIn) {

--- a/src/main/java/twilightforest/world/ChunkGeneratorTwilightForest.java
+++ b/src/main/java/twilightforest/world/ChunkGeneratorTwilightForest.java
@@ -23,8 +23,6 @@ import twilightforest.biomes.TFBiomes;
 import twilightforest.block.TFBlocks;
 import twilightforest.util.IntPair;
 
-import java.util.BitSet;
-
 // TODO: doc out all the vanilla copying
 public class ChunkGeneratorTwilightForest extends ChunkGeneratorTFBase {
 
@@ -46,7 +44,7 @@ public class ChunkGeneratorTwilightForest extends ChunkGeneratorTFBase {
 	public Chunk generateChunk(int x, int z) {
 		rand.setSeed(getSeed(x, z));
 
-		BitSet data = new BitSet(65536);
+		ChunkBitArray data = new ChunkBitArray();
 		setBlocksInChunk(x, z, data);
 		squishTerrain(data);
 
@@ -72,7 +70,7 @@ public class ChunkGeneratorTwilightForest extends ChunkGeneratorTFBase {
 	}
 
 	@Override
-	protected void initPrimer(ChunkPrimer primer, BitSet data) {
+	protected void initPrimer(ChunkPrimer primer, ChunkBitArray data) {
 
 		IBlockState water = Blocks.WATER.getDefaultState();
 		IBlockState stone = Blocks.STONE.getDefaultState();

--- a/src/main/java/twilightforest/world/ChunkGeneratorTwilightVoid.java
+++ b/src/main/java/twilightforest/world/ChunkGeneratorTwilightVoid.java
@@ -16,8 +16,6 @@ import twilightforest.TFConfig;
 import twilightforest.TFFeature;
 import twilightforest.biomes.TFBiomes;
 
-import java.util.BitSet;
-
 public class ChunkGeneratorTwilightVoid extends ChunkGeneratorTFBase {
 
 	private final boolean generateHollowTrees = TFConfig.dimension.skylightOaks;
@@ -30,7 +28,7 @@ public class ChunkGeneratorTwilightVoid extends ChunkGeneratorTFBase {
 	public Chunk generateChunk(int x, int z) {
 		rand.setSeed(getSeed(x, z));
 
-		BitSet data = new BitSet(65536);
+		ChunkBitArray data = new ChunkBitArray();
 		setBlocksInChunk(x, z, data);
 		squishTerrain(data);
 
@@ -52,7 +50,7 @@ public class ChunkGeneratorTwilightVoid extends ChunkGeneratorTFBase {
 	}
 
 	@Override
-	protected void initPrimer(ChunkPrimer primer, BitSet data) {
+	protected void initPrimer(ChunkPrimer primer, ChunkBitArray data) {
 
 		IBlockState stone = Blocks.STONE.getDefaultState();
 


### PR DESCRIPTION
This PR once again does not provide a huge improvement but shaves terrain generation time from a consistent 5.0 seconds in a sample world to just 4.2 seconds (and once again, consistently.) This is achieved mostly by replacing usages of BitSet with a custom and much simpler bit array implementation (<30 LOC). This implementation avoids as much extra work as possible, where as BitSet adds additional overhead for array resizing and for marking empty sections after clearing bits.

Additionally, biome block replacement was adjusted slightly to avoid a second `ChunkPrimer#setBlockState` call when replacing stone blocks in terrain, which again offers a very small improvement.