### PR TITLE
Fix wood door/trapdoor recipes

### DIFF
--- a/src/main/resources/assets/twilightforest/recipes/wood/canopy_door.json
+++ b/src/main/resources/assets/twilightforest/recipes/wood/canopy_door.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "item": "twilightforest:canopy_trapdoor",
+    "item": "twilightforest:canopy_door",
     "data": 0,
     "count": 3
   },

--- a/src/main/resources/assets/twilightforest/recipes/wood/darkwood_door.json
+++ b/src/main/resources/assets/twilightforest/recipes/wood/darkwood_door.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "item": "twilightforest:canopy_trapdoor",
+    "item": "twilightforest:dark_door",
     "data": 0,
     "count": 3
   },
@@ -12,7 +12,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "twilightforest:canopy_planks",
+      "item": "twilightforest:dark_planks",
       "data": 0
     }
   }

--- a/src/main/resources/assets/twilightforest/recipes/wood/darkwood_trapdoor.json
+++ b/src/main/resources/assets/twilightforest/recipes/wood/darkwood_trapdoor.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "item": "twilightforest:canopy_trapdoor",
+    "item": "twilightforest:dark_trapdoor",
     "data": 0,
     "count": 6
   },
@@ -11,7 +11,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "twilightforest:canopy_planks",
+      "item": "twilightforest:dark_planks",
       "data": 0
     }
   }

--- a/src/main/resources/assets/twilightforest/recipes/wood/mangrove_door.json
+++ b/src/main/resources/assets/twilightforest/recipes/wood/mangrove_door.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "item": "twilightforest:canopy_trapdoor",
+    "item": "twilightforest:mangrove_door",
     "data": 0,
     "count": 3
   },
@@ -12,7 +12,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "twilightforest:canopy_planks",
+      "item": "twilightforest:mangrove_planks",
       "data": 0
     }
   }

--- a/src/main/resources/assets/twilightforest/recipes/wood/mangrove_trapdoor.json
+++ b/src/main/resources/assets/twilightforest/recipes/wood/mangrove_trapdoor.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "item": "twilightforest:canopy_trapdoor",
+    "item": "twilightforest:mangrove_trapdoor",
     "data": 0,
     "count": 6
   },
@@ -11,7 +11,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "twilightforest:canopy_planks",
+      "item": "twilightforest:mangrove_planks",
       "data": 0
     }
   }

--- a/src/main/resources/assets/twilightforest/recipes/wood/mine_door.json
+++ b/src/main/resources/assets/twilightforest/recipes/wood/mine_door.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "item": "twilightforest:canopy_trapdoor",
+    "item": "twilightforest:mine_door",
     "data": 0,
     "count": 3
   },
@@ -12,7 +12,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "twilightforest:canopy_planks",
+      "item": "twilightforest:mine_planks",
       "data": 0
     }
   }

--- a/src/main/resources/assets/twilightforest/recipes/wood/mine_trapdoor.json
+++ b/src/main/resources/assets/twilightforest/recipes/wood/mine_trapdoor.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "item": "twilightforest:canopy_trapdoor",
+    "item": "twilightforest:mine_trapdoor",
     "data": 0,
     "count": 6
   },
@@ -11,7 +11,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "twilightforest:canopy_planks",
+      "item": "twilightforest:mine_planks",
       "data": 0
     }
   }

--- a/src/main/resources/assets/twilightforest/recipes/wood/sort_door.json
+++ b/src/main/resources/assets/twilightforest/recipes/wood/sort_door.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "item": "twilightforest:canopy_trapdoor",
+    "item": "twilightforest:sort_door",
     "data": 0,
     "count": 3
   },
@@ -12,7 +12,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "twilightforest:canopy_planks",
+      "item": "twilightforest:sort_planks",
       "data": 0
     }
   }

--- a/src/main/resources/assets/twilightforest/recipes/wood/sort_trapdoor.json
+++ b/src/main/resources/assets/twilightforest/recipes/wood/sort_trapdoor.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "item": "twilightforest:canopy_trapdoor",
+    "item": "twilightforest:sort_trapdoor",
     "data": 0,
     "count": 6
   },
@@ -11,7 +11,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "twilightforest:canopy_planks",
+      "item": "twilightforest:sort_planks",
       "data": 0
     }
   }


### PR DESCRIPTION
The recipes for some wood-based doors and trapdoors seem to be incorrect, probably due to some copy-pasting error.

I think it is unrelated (may be a candidate for a seperate issue) but all of the Twilight Forest doors (not trapdoors) also have invalid item models - the block models work fine.