### PR TITLE
More Patchouli pages

### DIFF
--- a/src/main/resources/assets/twilightforest/advancements/alt/treasures/fiery_blood_tears.json
+++ b/src/main/resources/assets/twilightforest/advancements/alt/treasures/fiery_blood_tears.json
@@ -1,0 +1,10 @@
+{
+  "parent": "twilightforest:alt/root",
+  "criteria": {
+    "armor": { "trigger": "twilightforest:has_advancement", "conditions": { "advancement": "twilightforest:alt/treasures/fiery_armor_set" }},
+    "tools": { "trigger": "twilightforest:has_advancement", "conditions": { "advancement": "twilightforest:alt/treasures/fiery_tool_set" }}
+  },
+  "requirements": [
+    [ "armor", "tools" ]
+  ]
+}

--- a/src/main/resources/assets/twilightforest/advancements/alt/treasures/minotaur_axe_diamond.json
+++ b/src/main/resources/assets/twilightforest/advancements/alt/treasures/minotaur_axe_diamond.json
@@ -1,0 +1,9 @@
+{
+  "parent": "twilightforest:alt/root",
+  "criteria": {
+    "axe": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "item": "twilightforest:minotaur_axe" }]}}
+  },
+  "requirements": [
+    [ "axe" ]
+  ]
+}

--- a/src/main/resources/assets/twilightforest/advancements/alt/treasures/minotaur_axe_gold.json
+++ b/src/main/resources/assets/twilightforest/advancements/alt/treasures/minotaur_axe_gold.json
@@ -1,0 +1,9 @@
+{
+  "parent": "twilightforest:alt/root",
+  "criteria": {
+    "axe": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "item": "twilightforest:minotaur_axe_gold" }]}}
+  },
+  "requirements": [
+    [ "axe" ]
+  ]
+}

--- a/src/main/resources/assets/twilightforest/advancements/alt/treasures/minotaur_axes.json
+++ b/src/main/resources/assets/twilightforest/advancements/alt/treasures/minotaur_axes.json
@@ -1,0 +1,16 @@
+{
+  "parent": "twilightforest:alt/root",
+  "criteria": {
+    "gold": {
+      "trigger": "twilightforest:has_advancement",
+      "conditions": { "advancement": "twilightforest:alt/treasures/minotaur_axe_gold" }
+    },
+    "diamond": {
+      "trigger": "twilightforest:has_advancement",
+      "conditions": { "advancement": "twilightforest:alt/treasures/minotaur_axe_diamond" }
+    }
+  },
+  "requirements": [
+    [ "gold", "diamond" ]
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/bosses/hydra.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/bosses/hydra.json
@@ -8,7 +8,11 @@
     {
       "type": "entity",
       "entity": "twilightforest:hydra",
-      "text": "Hail hydra"
+      "text": "Hail Hydra"
+    },
+    {
+      "type": "text",
+      "text": "The great monster of the Fire Swamp, the Hydra has a tough hide and each head having its own mind and method of attacking. Ranging from fiery breaths, exploding mortars, and a devastating bite attack, along with the ability to regenerate heads, this thing will not stop at anything."
     }
   ]
 }

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/bosses/minoshroom.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/bosses/minoshroom.json
@@ -12,7 +12,7 @@
     },
     {
       "type": "text",
-      "text": "This terrifying beast of the Labyrinth could destroy any uncaring adventurer quickly. Their weapon of choice, a Diamond Minotaur Axe, can tear down any defence, and their charging attack could catch anyone off guard in one fell swoop.$(br)Caution should be exercised while trying to slay the Minoshroom."
+      "text": "This terrifying beast of the Labyrinth could destroy any uncaring adventurer quickly. Their weapon of choice, a Diamond Minotaur Axe, can tear down any defense, and their charging attack could catch anyone off guard in one fell swoop.$(br)Caution should be exercised while trying to slay the Minoshroom."
     }
   ]
 }

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/bosses/minoshroom.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/bosses/minoshroom.json
@@ -8,7 +8,11 @@
     {
       "type": "entity",
       "entity": "twilightforest:minoshroom{HandItems:[{id:\"twilightforest:minotaur_axe\",Count:1}]}",
-      "text": "He just wanted to axe you a question"
+      "text": "He just wanted to axe you a question."
+    },
+    {
+      "type": "text",
+      "text": "This terrifying beast of the Labyrinth could destroy any uncaring adventurer quickly. Their weapon of choice, a Diamond Minotaur Axe, can tear down any defence, and their charging attack could catch anyone off guard in one fell swoop.$(br)Caution should be exercised while trying to slay the Minoshroom."
     }
   ]
 }

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/entities/maze_slime.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/entities/maze_slime.json
@@ -8,7 +8,11 @@
     {
       "type": "entity",
       "entity": "twilightforest:maze_slime{Size:1}",
-      "text": "things and stuff"
+      "text": ""
+    },
+    {
+      "type": "text",
+      "text": "Strange Slimes found within the confines of the Labyrinth. They look and feel like any other Slime, but their slimy bodies resemble Mazestone Bricks. Though they appear to be nothing special, they seem to contain a special secret within them; a rare treasure, perhaps?"
     }
   ]
 }

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/entities/minotaur.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/entities/minotaur.json
@@ -8,7 +8,16 @@
     {
       "type": "entity",
       "entity": "twilightforest:minotaur",
-      "text": "things and stuff"
+      "text": ""
+    },
+    {
+      "type": "text",
+      "text": "Humanoid beasts that roam the Labyrinth. These part-Cow, part-human beasts each have a Golden Axe as their choice of weapon, tearing defences down. Their charge attack happens quickly and swiftly, and in groups, they overwhelm any careful adventurer."
+    },
+    {
+      "type": "text",
+      "advancement": "twilightforest:alt/treasures/minotaur_axe_gold",
+      "text": "Beware the Minotaurs with the Golden Minotaur Axe. They may be rare, but their different choice of weapon is a deadly choice, with more damage to deal."
     }
   ]
 }

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/entities/minotaur.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/entities/minotaur.json
@@ -12,7 +12,7 @@
     },
     {
       "type": "text",
-      "text": "Humanoid beasts that roam the Labyrinth. These part-Cow, part-human beasts each have a Golden Axe as their choice of weapon, tearing defences down. Their charge attack happens quickly and swiftly, and in groups, they overwhelm any careful adventurer."
+      "text": "Humanoid beasts that roam the Labyrinth. These part-cow, part-human beasts each have a Golden Axe as their choice of weapon, tearing defenses down. Their charge attack happens quickly and swiftly, and in groups, they overwhelm any careful adventurer."
     },
     {
       "type": "text",

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/sortnum_reference.txt
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/sortnum_reference.txt
@@ -113,6 +113,7 @@ minotaur.json
 
 5030
 mazebreaker_pickaxe.json
+minotaur_axes.json
 
 5040
 minoshroom.json
@@ -130,6 +131,9 @@ hydra_lair.json
 
 5110
 hydra.json
+
+5120
+fiery_blood_tears.json
 
 
 

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/fiery_blood_tears.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/fiery_blood_tears.json
@@ -1,0 +1,15 @@
+{
+  "name": "Fiery Blood and Tears",
+  "icon": "twilightforest:fiery_blood",
+  "category": "treasures",
+  "advancement": "twilightforest:alt/treasures/fiery_blood_tears",
+  "sortnum": 5120,
+  "pages": [
+    {
+      "type": "twilightforest:gallery",
+      "title": "Fiery Blood and Tears",
+      "item_list": "twilightforest:fiery_blood|twilightforest:fiery_tears",
+      "text": "Small vials containing a hot liquid. Though containing different liquids, the properties have the same, burning properties, applicable for making equipment burn enemies. It seems to come from two powerful monsters."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/fiery_blood_tears.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/fiery_blood_tears.json
@@ -9,7 +9,7 @@
       "type": "twilightforest:gallery",
       "title": "Fiery Blood and Tears",
       "item_list": "twilightforest:fiery_blood|twilightforest:fiery_tears",
-      "text": "Small vials containing a hot liquid. Though containing different liquids, the properties have the same, burning properties, applicable for making equipment burn enemies. It seems to come from two powerful monsters."
+      "text": "Small vials containing a hot substance. The burning essence within these vials are so hot, they can be infused into Iron to turn them into a fiery metal usable in crafting. It can be obtained from multiple powerful monsters."
     }
   ]
 }

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/foods.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/foods.json
@@ -13,7 +13,7 @@
       "title": "Hydra Chop",
       "item": "twilightforest:hydra_chop",
       "advancement": "twilightforest:alt/treasures/foods/hydra_chop",
-      "text": "A filling meal with just a single Hydra Chop. Eating this potent meat fills your hunger greatly and helps in health regeneration. Fitting for those that have conquered such a mighty beast."
+      "text": "A filling meal with just a single Hydra Chop. Eating this potent meat greatly satiates hunger and provides temporary rapid healing. Fitting for those that have conquered such a mighty beast."
     }, {
       "type": "spotlight",
       "title": "Maze Wafer",
@@ -35,7 +35,7 @@
       "title": "Meef Stroganoff",
       "item": "twilightforest:meef_stroganoff",
       "advancement": "twilightforest:progress_labyrinth",
-      "text": "Nutritious and hearty. Eating Meef Stroganoff empowers the adventurer and allows them to traverse into the Fire Swamp without fearing any heat-related issues. How kind of the Minoshroom, after all that effort?"
+      "text": "Nutritious and hearty. Eating Meef Stroganoff not only empowers the adventurer but also allows them to enter the Fire Swamp safely without suffering from the heat. How kind of the Minoshroom after all that effort?"
     }, {
       "type": "text",
       "advancement": "twilightforest:alt/treasures/foods/experiment_115",

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/foods.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/foods.json
@@ -9,25 +9,33 @@
       "type": "text",
       "text": "Food glorious food"
     }, {
-      "type": "text",
+      "type": "spotlight",
+      "title": "Hydra Chop",
+      "item": "twilightforest:hydra_chop",
       "advancement": "twilightforest:alt/treasures/foods/hydra_chop",
-      "text": "things and stuff"
+      "text": "A filling meal with just a single Hydra Chop. Eating this potent meat fills your hunger greatly and helps in health regeneration. Fitting for those that have conquered such a mighty beast."
     }, {
-      "type": "text",
+      "type": "spotlight",
+      "title": "Maze Wafer",
+      "item": "twilightforest:maze_wafer",
       "advancement": "twilightforest:alt/treasures/foods/maze_wafer",
-      "text": "things and stuff"
+      "text": "Quick little snacks found in mazes. Though barely able to grant some saturation, it is perfect for exploring twisted landmarks when food becomes scarce."
     }, {
       "type": "text",
+      "title": "Meef",
+      "item": "twilightforest:cooked_meef",
       "advancement": "twilightforest:alt/treasures/foods/meef",
-      "text": "things and stuff"
+      "text": "Beef from a Minotaur. It's not very much if eaten raw, but cook it up and it is a valuable food item, rivalling the likes of Cooked Chicken."
     }, {
       "type": "text",
       "advancement": "twilightforest:alt/treasures/foods/vension",
       "text": "things and stuff"
     }, {
-      "type": "text",
+      "type": "spotlight",
+      "title": "Meef Stroganoff",
+      "item": "twilightforest:meef_stroganoff",
       "advancement": "twilightforest:progress_labyrinth",
-      "text": "things and stuff"
+      "text": "Nutritious and hearty. Eating Meef Stroganoff empowers the adventurer and allows them to traverse into the Fire Swamp without fearing any heat-related issues. How kind of the Minoshroom, after all that effort?"
     }, {
       "type": "text",
       "advancement": "twilightforest:alt/treasures/foods/experiment_115",

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/minotaur_axes.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/minotaur_axes.json
@@ -1,0 +1,25 @@
+{
+  "name": "Minotaur Axes",
+  "icon": "twilightforest:minotaur_axe",
+  "category": "treasures",
+  "advancement": "twilightforest:alt/treasures/minotaur_axes",
+  "sortnum": 5030,
+  "pages": [
+    {
+      "type": "text",
+      "text": "Finely forged weapons wielded by Minotaurs and the Minoshroom. At full force, they can be devastating."
+    }, {
+      "type": "spotlight",
+      "title": "Golden Minotaur Axe",
+      "item": "twilightforest:minotaur_axe_gold",
+      "advancement": "twilightforest:alt/treasures/minotaur_axe_gold",
+      "text": "Sharp, powerful, but incredibly frail. Only the most worthy of Minotaurs have these weapons."
+    }, {
+      "type": "spotlight",
+      "title": "Diamond Minotaur Axe",
+      "item": "twilightforest:minotaur_axe",
+      "advancement": "twilightforest:alt/treasures/minotaur_axe_diamond",
+      "text": "The most finely forge weapon, adorned with the strength of Diamond. This weapon is the choice of the Minoshroom, fitting for a powerful beast."
+    }
+  ]
+}

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/minotaur_axes.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/minotaur_axes.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "text",
-      "text": "Finely forged weapons wielded by Minotaurs and the Minoshroom. At full force, they can be devastating."
+      "text": "Finely forged weapons wielded by Minotaurs and the Minoshroom. They feel like any old axe, but the design of these axes are strange. Though light to hold, these axes feel weighty while running with them."
     }, {
       "type": "spotlight",
       "title": "Golden Minotaur Axe",
@@ -19,7 +19,7 @@
       "title": "Diamond Minotaur Axe",
       "item": "twilightforest:minotaur_axe",
       "advancement": "twilightforest:alt/treasures/minotaur_axe_diamond",
-      "text": "The most finely forge weapon, adorned with the strength of Diamond. This weapon is the choice of the Minoshroom, fitting for a powerful beast."
+      "text": "A finely forged weapon adorned with the strength of Diamond. This powerful weapon is the choice of the Minoshroom, fitting for a great beast."
     }
   ]
 }

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/trophies.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/treasures/trophies.json
@@ -25,13 +25,17 @@
       "advancement": "twilightforest:progress_lich",
       "text": "things and stuff"
     }, {
-      "type": "text",
+      "type": "spotlight",
+      "title": "Minoshroom Trophy",
+      "item": "twilightforest:trophy:6",
       "advancement": "twilightforest:progress_labyrinth",
-      "text": "things and stuff"
+      "text": "The trophy of the Minoshroom, bestowed to those who have bested the beast of the Labyrinth. Though iron-plated, it is still worth the well-fought battle of the brawn, or brain versus brawn, however the Minoshroom was slain."
     }, {
-      "type": "text",
+      "type": "spotlight",
+      "title": "Hydra Trophy",
+      "item": "twilightforest:trophy:2",
       "advancement": "twilightforest:progress_hydra",
-      "text": "things and stuff"
+      "text": "A trophy depicting one of the many heads of the Hydra. Though slaying a head only creates more, this reward from a heated battle is proof that a beast with regenerating heads can be slain. Seems like the mouth opens when there's no solid surface beneath the Trophy."
     }, {
       "type": "text",
       "advancement": "twilightforest:progress_knights",

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/world/biomes/twilight_swamp.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/world/biomes/twilight_swamp.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "text",
-      "text": "A large, damp expanse of the Twilight Forest resembling a Swamp. This place is swarming with Mosquitoes, and trespassing here will sicken any adventurer with an illness. Clearing this place requires one of the Twilight Lich's magical Scepters in order to repel the Mosquitoes. There are mounds in this biome, perhaps indicating a presence of landmarks?"
+      "text": "A large, damp expanse of the Twilight Forest resembling a Swamp. This place is swarming with Mosquitoes, and trespassing will sicken any adventurer with an illness. Clearing this place requires one of the Twilight Lich's magical Scepters in order to repel the Mosquitoes. There are mounds in this biome, perhaps indicating a presence of landmarks?"
     }, {
       "type": "text",
       "advancement": "twilightforest:alt/biomes/fire_swamp",

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/world/biomes/twilight_swamp.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/world/biomes/twilight_swamp.json
@@ -7,11 +7,11 @@
   "pages": [
     {
       "type": "text",
-      "text": "things and stuff"
+      "text": "A large, damp expanse of the Twilight Forest resembling a Swamp. This place is swarming with Mosquitoes, and trespassing here will sicken any adventurer with an illness. Clearing this place requires one of the Twilight Lich's magical Scepters in order to repel the Mosquitoes. There are mounds in this biome, perhaps indicating a presence of landmarks?"
     }, {
       "type": "text",
       "advancement": "twilightforest:alt/biomes/fire_swamp",
-      "text": "things and stuff"
+      "text": "In the center of the Twilight Swamp is the Fire Swamp. This rather temperate biome has high abundance of Lava, and jets that erupt smoke and flames, all spread across a rusty red landscape. Because of the heat, adventurers need good nutrition in order to pass into the biome. It is said that a terrific monster resides in the remains of a Large Hollow Hill."
     }
   ]
 }

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/world/major_landmarks/hydra_lair.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/world/major_landmarks/hydra_lair.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "type": "text",
-      "text": "things and stuff"
+      "text": "Deep within the Fire Swamp is the Hydra Lair: a Large Hollow Hill converted into the home of the Hydra. Still decorated with various rare ores, it's the perfect place to collect some treasures, with the exception of a giant mythical reptile standing in the midst of the treasure."
     }
   ]
 }

--- a/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/world/major_landmarks/labyrinth.json
+++ b/src/main/resources/assets/twilightforest/patchouli_books/guide/en_us/entries/world/major_landmarks/labyrinth.json
@@ -7,7 +7,17 @@
   "pages": [
     {
       "type": "text",
-      "text": "things and stuff"
+      "text": "Large, sprawling mazes that can be found beneath the Twilight Swamp biome. Locating one of these landmarks requires a good eye for terrain, as the entrance is hidden inside a hill the size of a Small Hollow Hill."
+    },
+    {
+      "type": "text",
+      "advancement": "twilightforest:alt/entities/minoshroom",
+      "text": "With some dedication and some navigation, an adventurer may come across the lair of the Minoshroom. Locked behind wooden fences and surrounded in fungus appears to be some chests with some loot, guarded by the beast of the Labyrinth."
+    },
+    {
+      "type": "text",
+      "advancement": "twilightforest:alt/treasures/mazebreaker_pickaxe",
+      "text": "Hidden deep within the walls of the Labyrinth appears to be a small, rigged vault. Careful adventurers can gather some rare, valuable materials, and a coveted Mazebreaker. Such find is quite the reward, but care must be exercised."
     }
   ]
 }


### PR DESCRIPTION
*runs into room with stack of pages*
I have things.

- Adds entries for Minotaur Axes, and Fiery Blood/Tears.
- Some pages got some actual text, others now use `spotlight` instead of `text` page type.
- Pages are linked to the Twilight Swamp and Fire Swamp. This includes Labyrinth and Hydra Lair, as well as the treasures, entities, and bosses.
- Added a couple advancements for the new pages.
- Sortnum file updated accordingly.

Logs are loaded appropriately, shouldn't crash. Open for grammar, spelling, or lore edits.