### PR TITLE
Update pack format version, fix mods.toml properties

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,17 +1,17 @@
 modLoader="javafml" #mandatory
 loaderVersion="[34,)"
 issueTrackerURL="https://github.com/TeamTwilight/twilightforest/issues" #optional
-displayURL="https://www.curseforge.com/minecraft/mc-mods/the-twilight-forest" #optional
-updateJSONURL="https://raw.githubusercontent.com/TeamTwilight/twilightforest/1.16.x/update.json"
-logoFile="logo.png" #optional
-credits="By Benimatic (Ben Mazur)" #optional
-authors="Benimatic, AtomicBlom, Drullkus, Killer_Demon, quadraxis, Tamaized, williewillus" #optional
 license="GNU LESSER GENERAL PUBLIC LICENSE Version 2.1"
 
 [[mods]]
 modId="twilightforest"
 version="${file.jarVersion}"
 displayName="The Twilight Forest"
+displayURL="https://www.curseforge.com/minecraft/mc-mods/the-twilight-forest" #optional
+updateJSONURL="https://raw.githubusercontent.com/TeamTwilight/twilightforest/1.16.x/update.json"
+logoFile="twilightforest_logo.png" #optional
+credits="By Benimatic (Ben Mazur)" #optional
+authors="Benimatic, AtomicBlom, Drullkus, Killer_Demon, quadraxis, Tamaized, williewillus" #optional
 description='''
 An enchanted forest dimension.'''
 

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 4,
+    "pack_format": 6,
     "description": "Resources used for TwilightForest"
   }
 }


### PR DESCRIPTION
 * Updates the `pack_format` in `pack.mcmeta` to `6`, which is the pack format starting from 1.16.2 up to today's version.<sup>[1](#pack-format)</sup>
 * Fix placement of some properties in `mods.toml`:
    `credits`, `authors`, `logoFile`, `updateJSONURL`, and `displayURL` must be under a mod declaration (`[[mods]]`).<sup>[2](#mods-toml)</sup>
    * Fix the filename reference to the logo file in `logoFile`.

<sup><a id="pack-format">1. </a>[**Resource Pack § History**](https://minecraft.gamepedia.com/Resource_Pack#History) from _minecraft.gamepedia.com_: `1.16.2 | Release Candidate 1 | Changed format number to 6, due to changes to wall blocks made in 1.16 according to MC-197275.`; [MC-197275](https://bugs.mojang.com/browse/MC-197275)</sup>
<sup><a id="mods-toml">2. </a>[**Proper Mod Structuring § Mod Properties**](https://forge.gemwire.uk/index.php?title=Proper_Mod_Structuring#Mod_Properties) from _forge.gemwire.uk_</sup>

