### PR TITLE
Fix ironwood smelting and blasting recipes

### DIFF
--- a/src/main/resources/data/twilightforest/recipes/material/ironwood_ingot.json
+++ b/src/main/resources/data/twilightforest/recipes/material/ironwood_ingot.json
@@ -3,9 +3,7 @@
   "ingredient": {
     "item": "twilightforest:raw_ironwood"
   },
-  "result": {
-    "item": "twilightforest:ironwood_ingot"
-  },
+  "result": "twilightforest:ironwood_ingot",
   "experience": 0.7,
   "cookingtime": 200
 }

--- a/src/main/resources/data/twilightforest/recipes/material/ironwood_ingot_from_blasting.json
+++ b/src/main/resources/data/twilightforest/recipes/material/ironwood_ingot_from_blasting.json
@@ -3,9 +3,7 @@
   "ingredient": {
     "item": "twilightforest:raw_ironwood"
   },
-  "result": {
-    "item": "twilightforest:ironwood_ingot"
-  },
+  "result": "twilightforest:ironwood_ingot",
   "experience": 0.7,
   "cookingtime": 100
 }


### PR DESCRIPTION
The ironwood ingot smelting and blasting recipes are currently not working, discovered on version 4.0.103 for Fabric. I compared the formatting on the two recipes to that of the knightmetal ingot recipes, which are working, and adjusted the syntax on the ironwood ones to match. When I tested this, it worked. The syntax error exists in the forge recipe files as well, or else i wouldn't have been able to make this pull request.