### PR TITLE
Fixed Optifine Compatibility

### DIFF
--- a/src/main/resources/META-INF/asm/maprendercontext.js
+++ b/src/main/resources/META-INF/asm/maprendercontext.js
@@ -46,10 +46,10 @@ function initializeCoreMod() {
             },
             'transformer': function (/*org.objectweb.asm.tree.MethodNode*/ methodNode) {
                 var /*org.objectweb.asm.tree.InsnList*/ instructions = methodNode.instructions;
-                var i = 0;
+                var i = -1;
                 for (var index = instructions.size() - 1; index > 0; index--) {
                     var /*org.objectweb.asm.tree.FieldInsnNode*/ node = instructions.get(index);
-                    if (i === 0 &&
+                    if (i === -1 &&
 
                         node instanceof FieldInsnNode &&
 
@@ -63,6 +63,12 @@ function initializeCoreMod() {
                         i = index + 1;
 
                 }
+
+                if (i === -1) {
+                    // Must be optifine... Optifine checks for instanceof MapItem, so this patch won't be needed anyway.
+                    return methodNode;
+                }
+
                 instructions.insert(
                     instructions.get(i),
                     ASM.listOf(


### PR DESCRIPTION
In Vanilla/Forge, the renderArmWithItem function checks if the item is specifically Items.FILLED_MAP but optifine checks if it's an instanceof MapItem.

This prevents the game from launching if installed along side Optifine. Since Optifine checks for any map item, the patch isn't needed with Optifine at all. So I just did some error checking and if the patch fails, it will be ignored. With this fixed, the mod runs perfectly with Optifine including Shaders.

I know Optifine can be a pain to deal with, and this took awhile to figure out, but at least with this fix it works now.

Also I should mention I could not get this mod to run in the dev environment with the forge version set in gradle.properties so I updated it to 40.1.57 but did not include that change in my PR as it's unrelated.