### PR TITLE
Resolve unused CoreMod

### DIFF
--- a/src/main/resources/META-INF/coremods.json
+++ b/src/main/resources/META-INF/coremods.json
@@ -5,5 +5,6 @@
   "multipart": "META-INF/asm/multipart.js",
   "foliage": "META-INF/asm/foliage.js",
   "mount": "META-INF/asm/mount.js",
-  "book": "META-INF/asm/book.js"
+  "book": "META-INF/asm/book.js",
+  "conquered": "META-INF/asm/conquered.js"
 }


### PR DESCRIPTION
There is an unused CoreMod named [conquered.js](https://github.com/TeamTwilight/twilightforest/blob/1.19.x/src/main/resources/META-INF/asm/conquered.js) not found in [coremods.json](https://github.com/TeamTwilight/twilightforest/blob/1.19.x/src/main/resources/META-INF/coremods.json) when you committed https://github.com/TeamTwilight/twilightforest/commit/f10c62dbe1b684903fc5d116922d5f9cc3c3d674.