### PR TITLE
Map Atlases Integration

### DIFF
--- a/src/main/java/twilightforest/TFMazeMapData.java
+++ b/src/main/java/twilightforest/TFMazeMapData.java
@@ -24,6 +24,7 @@ public class TFMazeMapData extends MapItemSavedData {
 	private static final Map<String, TFMazeMapData> CLIENT_DATA = new HashMap<>();
 
 	public int yCenter;
+	public boolean ore;
 
 	public TFMazeMapData(int x, int z, byte scale, boolean trackpos, boolean unlimited, boolean locked, ResourceKey<Level> dim) {
 		super(x, z, scale, trackpos, unlimited, locked, dim);

--- a/src/main/java/twilightforest/TFMazeMapData.java
+++ b/src/main/java/twilightforest/TFMazeMapData.java
@@ -87,6 +87,6 @@ public class TFMazeMapData extends MapItemSavedData {
 	@Override
 	public Packet<?> getUpdatePacket(int mapId, Player player) {
 		Packet<?> packet = super.getUpdatePacket(mapId, player);
-		return packet instanceof ClientboundMapItemDataPacket mapItemDataPacket ? TFPacketHandler.CHANNEL.toVanillaPacket(new MazeMapPacket(mapItemDataPacket), NetworkDirection.PLAY_TO_CLIENT) : packet;
+		return packet instanceof ClientboundMapItemDataPacket mapItemDataPacket ? TFPacketHandler.CHANNEL.toVanillaPacket(new MazeMapPacket(mapItemDataPacket, ore, yCenter), NetworkDirection.PLAY_TO_CLIENT) : packet;
 	}
 }

--- a/src/main/java/twilightforest/TFMazeMapData.java
+++ b/src/main/java/twilightforest/TFMazeMapData.java
@@ -44,6 +44,7 @@ public class TFMazeMapData extends MapItemSavedData {
 		tfdata.trackedDecorationCount = data.trackedDecorationCount;
 
 		tfdata.yCenter = nbt.getInt("yCenter");
+		tfdata.ore = nbt.getBoolean("mapOres");
 
 		return tfdata;
 	}
@@ -52,6 +53,7 @@ public class TFMazeMapData extends MapItemSavedData {
 	public CompoundTag save(CompoundTag nbt) {
 		CompoundTag ret = super.save(nbt);
 		ret.putInt("yCenter", this.yCenter);
+		ret.putBoolean("mapOres", this.ore);
 		return ret;
 	}
 

--- a/src/main/java/twilightforest/item/MazeMapItem.java
+++ b/src/main/java/twilightforest/item/MazeMapItem.java
@@ -56,13 +56,13 @@ public class MazeMapItem extends MapItem {
 	protected TFMazeMapData getCustomMapData(ItemStack stack, Level level) {
 		TFMazeMapData mapdata = getData(stack, level);
 		if (mapdata == null && !level.isClientSide()) {
-			mapdata = MazeMapItem.createMapData(stack, level, level.getLevelData().getXSpawn(), level.getLevelData().getZSpawn(), 0, false, false, level.dimension(), level.getLevelData().getYSpawn());
+			mapdata = MazeMapItem.createMapData(stack, level, level.getLevelData().getXSpawn(), level.getLevelData().getZSpawn(), 0, false, false, level.dimension(), level.getLevelData().getYSpawn(), mapOres);
 		}
 
 		return mapdata;
 	}
 
-	private static TFMazeMapData createMapData(ItemStack stack, Level level, int x, int z, int scale, boolean trackingPosition, boolean unlimitedTracking, ResourceKey<Level> dimension, int y) {
+	private static TFMazeMapData createMapData(ItemStack stack, Level level, int x, int z, int scale, boolean trackingPosition, boolean unlimitedTracking, ResourceKey<Level> dimension, int y, boolean ore) {
 		int i = level.getFreeMapId();
 
 		int mapSize = 128 * (1 << scale);
@@ -73,6 +73,7 @@ public class MazeMapItem extends MapItem {
 
 		TFMazeMapData mapdata = new TFMazeMapData(scaledX, scaledZ, (byte) scale, trackingPosition, unlimitedTracking, false, dimension);
 		mapdata.calculateMapCenter(level, x, y, z); // call our own map center calculation
+		mapData.ore = ore;
 		TFMazeMapData.registerMazeMapData(level, mapdata, getMapName(i)); // call our own register method
 		stack.getOrCreateTag().putInt("map", i);
 		return mapdata;

--- a/src/main/java/twilightforest/item/MazeMapItem.java
+++ b/src/main/java/twilightforest/item/MazeMapItem.java
@@ -41,7 +41,7 @@ public class MazeMapItem extends MapItem {
 
 	public static ItemStack setupNewMap(Level level, int worldX, int worldZ, byte scale, boolean trackingPosition, boolean unlimitedTracking, int worldY, boolean mapOres) {
 		ItemStack itemstack = new ItemStack(mapOres ? TFItems.FILLED_ORE_MAP.get() : TFItems.FILLED_MAZE_MAP.get());
-		createMapData(itemstack, level, worldX, worldZ, scale, trackingPosition, unlimitedTracking, level.dimension(), worldY);
+		createMapData(itemstack, level, worldX, worldZ, scale, trackingPosition, unlimitedTracking, level.dimension(), worldY, mapOres);
 		return itemstack;
 	}
 
@@ -73,7 +73,7 @@ public class MazeMapItem extends MapItem {
 
 		TFMazeMapData mapdata = new TFMazeMapData(scaledX, scaledZ, (byte) scale, trackingPosition, unlimitedTracking, false, dimension);
 		mapdata.calculateMapCenter(level, x, y, z); // call our own map center calculation
-		mapData.ore = ore;
+		mapdata.ore = ore;
 		TFMazeMapData.registerMazeMapData(level, mapdata, getMapName(i)); // call our own register method
 		stack.getOrCreateTag().putInt("map", i);
 		return mapdata;

--- a/src/main/java/twilightforest/network/MazeMapPacket.java
+++ b/src/main/java/twilightforest/network/MazeMapPacket.java
@@ -17,17 +17,25 @@ import java.util.function.Supplier;
 public class MazeMapPacket {
 
 	private final ClientboundMapItemDataPacket inner;
+	private final boolean ore;
+	private final int yCenter;
 
-	public MazeMapPacket(ClientboundMapItemDataPacket inner) {
+	public MazeMapPacket(ClientboundMapItemDataPacket inner, boolean ore, int yCenter) {
 		this.inner = inner;
+		this.ore = ore;
+		this.yCenter = yCenter;
 	}
 
 	public MazeMapPacket(FriendlyByteBuf buf) {
 		this.inner = new ClientboundMapItemDataPacket(buf);
+		this.ore = buf.readBoolean();
+		this.yCenter = buf.readVarInt();
 	}
 
 	public void encode(FriendlyByteBuf buf) {
 		this.inner.write(buf);
+		buf.writeBoolean(ore);
+		buf.writeVarInt(yCenter);
 	}
 
 	public static class Handler {
@@ -46,6 +54,8 @@ public class MazeMapPacket {
 						TFMazeMapData.registerMazeMapData(Minecraft.getInstance().level, mapdata, s);
 					}
 
+					mapdata.ore = message.ore;
+					mapdata.yCenter = message.yCenter;
 					message.inner.applyToMap(mapdata);
 					mapitemrenderer.update(message.inner.getMapId(), mapdata);
 				}


### PR DESCRIPTION
This PR allows the client to receive extra information about maze map data, allowing Maze Maps to be correctly used withing map atlases as the mod needs that data to be present on the client to tell the maps apart, display each in their own group

Apologies if some typo slipped, i did this in github web :/