### PR TITLE
Fixing aurora shader vertex and fragment locations

### DIFF
--- a/src/main/resources/assets/twilightforest/shaders/core/aurora/aurora.json
+++ b/src/main/resources/assets/twilightforest/shaders/core/aurora/aurora.json
@@ -4,8 +4,8 @@
 	"srcrgb": "srcalpha",
 	"dstrgb": "1-srcalpha"
   },
-  "vertex": "twilightforest:/aurora/aurora",
-  "fragment": "twilightforest:/aurora/aurora",
+  "vertex": "twilightforest:aurora/aurora",
+  "fragment": "twilightforest:aurora/aurora",
   "attributes": [
 	"Position",
     "Color"


### PR DESCRIPTION
The shader was not loaded at init phase due to the incorrect vertex and fragment locations