### PR TITLE
Fix holes in minotaur labyrinth

### DIFF
--- a/src/main/java/twilightforest/world/components/structures/minotaurmaze/MinotaurMazeComponent.java
+++ b/src/main/java/twilightforest/world/components/structures/minotaurmaze/MinotaurMazeComponent.java
@@ -278,8 +278,8 @@ public class MinotaurMazeComponent extends TFStructureComponentOld {
 		// clear the area
 		generateAirBox(world, sbb, 1, 1, 1, getDiameter(), 4, getDiameter());
 		boolean onlyReplaceCeiling = this.level == 1;
-		generateBox(world, sbb, 1, 5, 1, getDiameter(), 5, getDiameter(), TFBlocks.MAZESTONE.value().defaultBlockState(), stone, onlyReplaceCeiling);
-		generateBox(world, sbb, 1, 0, 1, getDiameter(), 0, getDiameter(), TFBlocks.MAZESTONE_MOSAIC.value().defaultBlockState(), stone, false);
+		generateBox(world, sbb, 1, 5, 1, getDiameter() + 1, 5, getDiameter() + 1, TFBlocks.MAZESTONE.value().defaultBlockState(), stone, onlyReplaceCeiling);
+		generateBox(world, sbb, 1, 0, 1, getDiameter() + 1, 0, getDiameter() + 1, TFBlocks.MAZESTONE_MOSAIC.value().defaultBlockState(), stone, false);
 
 		maze.headBlockState = TFBlocks.DECORATIVE_MAZESTONE.value().defaultBlockState();
 		maze.wallBlockState = TFBlocks.MAZESTONE_BRICK.value().defaultBlockState();


### PR DESCRIPTION
I fixed issue [#1922](https://github.com/TeamTwilight/twilightforest/issues/1922).

I increased x and z size of floor and roof of the minotaur labyrinth lowest level by 1.

Before:
![Before](https://github.com/TeamTwilight/twilightforest/assets/97367938/1bed3d49-34c5-4c7c-a04b-443ba82d562d)

After:
![After](https://github.com/TeamTwilight/twilightforest/assets/97367938/93f097ca-da94-4541-b4e4-b9113c1cde3a)
