### PR TITLE
Fix #1984

### DIFF
--- a/src/main/java/twilightforest/world/NoReturnTeleporter.java
+++ b/src/main/java/twilightforest/world/NoReturnTeleporter.java
@@ -1,11 +1,78 @@
 package twilightforest.world;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.portal.PortalInfo;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.common.util.ITeleporter;
+import org.jetbrains.annotations.Nullable;
+import twilightforest.TwilightForestMod;
+import twilightforest.init.TFDimension;
+
+import java.util.function.Function;
 
 public class NoReturnTeleporter extends TFTeleporter {
     public NoReturnTeleporter() {
         super(false);
+    }
+
+    @Nullable
+    @Override
+    public PortalInfo getPortalInfo(Entity entity, ServerLevel dest, Function<ServerLevel, PortalInfo> defaultPortalInfo) {
+        PortalInfo pos;
+        TeleporterCache cache = TeleporterCache.get(dest);
+
+        // Scale the coords based on the dimension type coordinate_scale
+        ServerLevel tfDim = dest.getServer().getLevel(TFDimension.DIMENSION_KEY);
+        double scale = tfDim == null ? 0.125D : tfDim.dimensionType().coordinateScale();
+        scale = dest.dimension().equals(TFDimension.DIMENSION_KEY) ? 1F / scale : scale;
+        BlockPos destPos = dest.getWorldBorder().clampToBounds(entity.blockPosition().getX() * scale, entity.blockPosition().getY(), entity.blockPosition().getZ() * scale);
+
+        if ((pos = placeInExistingPortal(cache, dest, entity, destPos)) == null) { //This isn't necessary, but whatever, might as well be safe
+            TwilightForestMod.LOGGER.debug("Did not find existing portal, making a new one.");
+            pos = moveToSafeCoords(dest, entity, destPos);
+            pos = placePosition(entity, dest, pos.pos);
+        }
+
+        return pos == null ? this.isVanilla() ? defaultPortalInfo.apply(dest) : new PortalInfo(entity.position(), Vec3.ZERO, entity.getYRot(), entity.getXRot()) : pos;
+    }
+
+    private static PortalInfo placePosition(Entity entity, ServerLevel world, Vec3 pos) {
+        // ensure area is populated first
+        loadSurroundingArea(world, pos);
+
+        BlockPos spot = findPortalCoords(world, pos, blockPos -> isPortalAt(world, blockPos));
+        String name = entity.getName().getString();
+
+        if (spot != null) {
+            TwilightForestMod.LOGGER.debug("Found existing portal for {} at {}", name, spot);
+            return makePortalInfo(entity, Vec3.atCenterOf(spot.above()));
+        }
+
+        spot = findPortalCoords(world, pos, blockpos -> isIdealForPortal(world, blockpos));
+
+        if (spot != null) {
+            TwilightForestMod.LOGGER.debug("Found ideal portal spot for {} at {}", name, spot);
+            return makePortalInfo(entity, Vec3.atCenterOf(spot.above()));
+        }
+
+        TwilightForestMod.LOGGER.debug("Did not find ideal portal spot, shooting for okay one for {}", name);
+        spot = findPortalCoords(world, pos, blockPos -> isOkayForPortal(world, blockPos));
+
+        if (spot != null) {
+            TwilightForestMod.LOGGER.debug("Found okay portal spot for {} at {}", name, spot);
+            return makePortalInfo(entity, Vec3.atCenterOf(spot.above()));
+        }
+
+        // well I don't think we can actually just return and fail here
+        TwilightForestMod.LOGGER.debug("Did not even find an okay portal spot, just making a random one for {}", name);
+
+        // adjust the portal height based on what world we're traveling to
+        double yFactor = getYFactor(world);
+        // modified copy of base Teleporter method:
+        return makePortalInfo(entity, entity.getX(), (entity.getY() * yFactor) - 1.0, entity.getZ());
     }
 
     @Override

--- a/src/main/java/twilightforest/world/NoReturnTeleporter.java
+++ b/src/main/java/twilightforest/world/NoReturnTeleporter.java
@@ -36,7 +36,7 @@ public class NoReturnTeleporter extends TFTeleporter {
             pos = placePosition(entity, dest, pos.pos);
         }
 
-        return pos == null ? this.isVanilla() ? defaultPortalInfo.apply(dest) : new PortalInfo(entity.position(), Vec3.ZERO, entity.getYRot(), entity.getXRot()) : pos;
+        return pos; //The original method has a null check in place. We don't here as placePosition always returns a position, since no portal is made anyway
     }
 
     private static PortalInfo placePosition(Entity entity, ServerLevel world, Vec3 pos) {

--- a/src/main/java/twilightforest/world/NoReturnTeleporter.java
+++ b/src/main/java/twilightforest/world/NoReturnTeleporter.java
@@ -18,25 +18,11 @@ public class NoReturnTeleporter extends TFTeleporter {
         super(false);
     }
 
-    @Nullable
     @Override
-    public PortalInfo getPortalInfo(Entity entity, ServerLevel dest, Function<ServerLevel, PortalInfo> defaultPortalInfo) {
-        PortalInfo pos;
-        TeleporterCache cache = TeleporterCache.get(dest);
-
-        // Scale the coords based on the dimension type coordinate_scale
-        ServerLevel tfDim = dest.getServer().getLevel(TFDimension.DIMENSION_KEY);
-        double scale = tfDim == null ? 0.125D : tfDim.dimensionType().coordinateScale();
-        scale = dest.dimension().equals(TFDimension.DIMENSION_KEY) ? 1F / scale : scale;
-        BlockPos destPos = dest.getWorldBorder().clampToBounds(entity.blockPosition().getX() * scale, entity.blockPosition().getY(), entity.blockPosition().getZ() * scale);
-
-        if ((pos = placeInExistingPortal(cache, dest, entity, destPos)) == null) { //This isn't necessary, but whatever, might as well be safe
-            TwilightForestMod.LOGGER.debug("Did not find existing portal, making a new one.");
-            pos = moveToSafeCoords(dest, entity, destPos);
-            pos = placePosition(entity, dest, pos.pos);
-        }
-
-        return pos; //The original method has a null check in place. We don't here as placePosition always returns a position, since no portal is made anyway
+    protected @Nullable PortalInfo createPosition(ServerLevel dest, Entity entity, BlockPos destPos, TeleporterCache cache) {
+        PortalInfo info = moveToSafeCoords(dest, entity, destPos);
+        info = placePosition(entity, dest, info.pos);
+        return info;
     }
 
     private static PortalInfo placePosition(Entity entity, ServerLevel world, Vec3 pos) {
@@ -73,10 +59,5 @@ public class NoReturnTeleporter extends TFTeleporter {
         double yFactor = getYFactor(world);
         // modified copy of base Teleporter method:
         return makePortalInfo(entity, entity.getX(), (entity.getY() * yFactor) - 1.0, entity.getZ());
-    }
-
-    @Override
-    protected BlockPos makePortalAt(Level world, BlockPos pos) {
-        return pos;
     }
 }

--- a/src/main/java/twilightforest/world/TFTeleporter.java
+++ b/src/main/java/twilightforest/world/TFTeleporter.java
@@ -71,7 +71,7 @@ public class TFTeleporter implements ITeleporter {
 	}
 
 	@Nullable
-	private static PortalInfo placeInExistingPortal(TeleporterCache cache, ServerLevel destDim, Entity entity, BlockPos pos) {
+	protected static PortalInfo placeInExistingPortal(TeleporterCache cache, ServerLevel destDim, Entity entity, BlockPos pos) {
 		boolean flag = true;
 		BlockPos blockpos;
 		ColumnPos columnPos = new ColumnPos(entity.blockPosition().getX(), entity.blockPosition().getZ()); // Must be the position from the src dim
@@ -214,11 +214,11 @@ public class TFTeleporter implements ITeleporter {
 		}
 	}
 
-	private static boolean isPortalAt(ServerLevel world, BlockPos pos) {
+	protected static boolean isPortalAt(ServerLevel world, BlockPos pos) {
 		return isPortal(world.getBlockState(pos));
 	}
 
-	private static PortalInfo moveToSafeCoords(ServerLevel world, Entity entity, BlockPos pos) {
+	protected static PortalInfo moveToSafeCoords(ServerLevel world, Entity entity, BlockPos pos) {
 		// if we're in enforced progression mode, check the biomes for safety
 		boolean checkProgression = LandmarkUtil.isProgressionEnforced(world);
 
@@ -323,7 +323,7 @@ public class TFTeleporter implements ITeleporter {
 		return null;
 	}
 
-	private void makePortal(TeleporterCache cache, Entity entity, ServerLevel world, Vec3 pos) {
+	protected void makePortal(TeleporterCache cache, Entity entity, ServerLevel world, Vec3 pos) {
 		ServerLevel src = entity.level() instanceof ServerLevel serverLevel ? serverLevel : null;
 
 		// ensure area is populated first
@@ -364,7 +364,7 @@ public class TFTeleporter implements ITeleporter {
 		cacheNewPortalCoords(cache, src, this.makePortalAt(world, BlockPos.containing(entity.getX(), (entity.getY() * yFactor) - 1.0, entity.getZ())), entity.blockPosition());
 	}
 
-	private static void loadSurroundingArea(ServerLevel world, Vec3 pos) {
+	protected static void loadSurroundingArea(ServerLevel world, Vec3 pos) {
 
 		int x = Mth.floor(pos.x()) >> 4;
 		int z = Mth.floor(pos.y()) >> 4;
@@ -377,7 +377,7 @@ public class TFTeleporter implements ITeleporter {
 	}
 
 	@Nullable
-	private static BlockPos findPortalCoords(ServerLevel world, Vec3 loc, Predicate<BlockPos> predicate) {
+	protected static BlockPos findPortalCoords(ServerLevel world, Vec3 loc, Predicate<BlockPos> predicate) {
 		// adjust the height based on what world we're traveling to
 		double yFactor = getYFactor(world);
 		// modified copy of base Teleporter method:
@@ -422,7 +422,7 @@ public class TFTeleporter implements ITeleporter {
 		return spot;
 	}
 
-	private static double getYFactor(ServerLevel world) {
+	protected static double getYFactor(ServerLevel world) {
 		return world.dimension().location().equals(Level.OVERWORLD.location()) ? 2.0 : 0.5;
 	}
 
@@ -440,7 +440,7 @@ public class TFTeleporter implements ITeleporter {
 		cache.addBlockToCache(srcDim.dimension().location(), new ColumnPos(pos.south().east().getX(), pos.south().east().getZ()), new TFTeleporter.PortalPosition(exitPos, srcDim.getGameTime()));
 	}
 
-	private static boolean isIdealForPortal(ServerLevel world, BlockPos pos) {
+	protected static boolean isIdealForPortal(ServerLevel world, BlockPos pos) {
 		for (int potentialZ = 0; potentialZ < 4; potentialZ++) {
 			for (int potentialX = 0; potentialX < 4; potentialX++) {
 				for (int potentialY = 0; potentialY < 4; potentialY++) {
@@ -528,7 +528,7 @@ public class TFTeleporter implements ITeleporter {
 		return optional.map(Block::defaultBlockState).orElseGet(Blocks.SHORT_GRASS::defaultBlockState);
 	}
 
-	private static boolean isOkayForPortal(ServerLevel world, BlockPos pos) {
+	protected static boolean isOkayForPortal(ServerLevel world, BlockPos pos) {
 		for (int potentialZ = 0; potentialZ < 4; potentialZ++) {
 			for (int potentialX = 0; potentialX < 4; potentialX++) {
 				for (int potentialY = 0; potentialY < 4; potentialY++) {
@@ -543,11 +543,11 @@ public class TFTeleporter implements ITeleporter {
 		return true;
 	}
 
-	private static PortalInfo makePortalInfo(Entity entity, double x, double y, double z) {
+	protected static PortalInfo makePortalInfo(Entity entity, double x, double y, double z) {
 		return makePortalInfo(entity, new Vec3(x, y, z));
 	}
 
-	private static PortalInfo makePortalInfo(Entity entity, Vec3 pos) {
+	protected static PortalInfo makePortalInfo(Entity entity, Vec3 pos) {
 		return new PortalInfo(pos, Vec3.ZERO, entity.getYRot(), entity.getXRot());
 	}
 

--- a/src/main/java/twilightforest/world/TFTeleporter.java
+++ b/src/main/java/twilightforest/world/TFTeleporter.java
@@ -62,12 +62,18 @@ public class TFTeleporter implements ITeleporter {
 
 		if ((pos = placeInExistingPortal(cache, dest, entity, destPos)) == null) {
 			TwilightForestMod.LOGGER.debug("Did not find existing portal, making a new one.");
-			pos = moveToSafeCoords(dest, entity, destPos);
-			this.makePortal(cache, entity, dest, pos.pos);
-			pos = placeInExistingPortal(cache, dest, entity, BlockPos.containing(pos.pos));
+			pos = createPosition(dest, entity, destPos, cache);
 		}
 
 		return pos == null ? ITeleporter.super.getPortalInfo(entity, dest, defaultPortalInfo) : pos;
+	}
+
+	@Nullable
+	protected PortalInfo createPosition(ServerLevel dest, Entity entity, BlockPos destPos, TeleporterCache cache) {
+		PortalInfo info = moveToSafeCoords(dest, entity, destPos);
+		this.makePortal(cache, entity, dest, info.pos);
+		info = placeInExistingPortal(cache, dest, entity, BlockPos.containing(info.pos));
+		return info;
 	}
 
 	@Nullable


### PR DESCRIPTION
Doing a few runs with the specified config setup, this appears to mostly work. There was one instance I spawned in the Dark Forest, but I'm sure that's just because I was in Creative and did not have any Progression blocking me.

I haven't committed this because it's a little...ugly. Works, just doesn't look good. For one, NoReturnTeleporter now overrides `getPortalInfo` from TFTeleporter. Not terrible, but does copy a lot, so I feel it could just be in TFTeleporter. Second, a lot of things had to be made protected, since TFTeleporter had all the logic. I also made a modified version of `makePortal` that returns a PortalInfo so that the coordinates used there are directly used to set the position of the player.

TL;DR: I fixed, but I think it should be all in TFTeleporter.