### PR TITLE
Perform Ore Meter Scanning on serverside instead of clientside, divide block scans over its loading time

### DIFF
--- a/src/main/java/twilightforest/capabilities/OreScannerAttachment.java
+++ b/src/main/java/twilightforest/capabilities/OreScannerAttachment.java
@@ -1,0 +1,192 @@
+package twilightforest.capabilities;
+
+import com.google.common.collect.ImmutableMap;
+import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMaps;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.attachment.IAttachmentHolder;
+import net.neoforged.neoforge.attachment.IAttachmentSerializer;
+import net.neoforged.neoforge.common.Tags;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+public class OreScannerAttachment {
+	private static final OreScannerAttachment EMPTY = new OreScannerAttachment(BlockPos.ZERO, 0, 0, 0);
+
+	private final int xSpan, zSpan;
+	private final int area;
+	private final int scanDurationTicks;
+
+	private final BlockPos origin;
+	private final Object2IntMap<Block> blockCounter;
+
+	private int ticksProgressed = 0;
+
+	public static OreScannerAttachment scanFromCenter(BlockPos center, int range, int scanDurationTicks) {
+		int xChunkCenter = center.getX() >> 4;
+		int zChunkCenter = center.getZ() >> 4;
+
+		// Enforce alignment with chunk edges
+		BlockPos origin = new BlockPos(SectionPos.sectionToBlockCoord(xChunkCenter - range), 0, SectionPos.sectionToBlockCoord(zChunkCenter - range));
+		int xSpan = SectionPos.sectionToBlockCoord(xChunkCenter + range, 15) - origin.getX();
+		int zSpan = SectionPos.sectionToBlockCoord(zChunkCenter + range, 15) - origin.getZ();
+
+		return new OreScannerAttachment(origin, xSpan, zSpan, scanDurationTicks);
+	}
+
+	public OreScannerAttachment(BlockPos origin, int xSpan, int zSpan, int scanDurationTicks) {
+		this.origin = origin;
+		this.xSpan = xSpan;
+		this.zSpan = zSpan;
+
+		// Total horizontal coverage that the scanning region encompasses,
+		//  to be later multiplied by building height for actual volume
+		this.area = this.xSpan * this.zSpan;
+
+		this.scanDurationTicks = scanDurationTicks;
+
+		this.blockCounter = this.area <= 0 ? Object2IntMaps.emptyMap() : new Object2IntArrayMap<>();
+	}
+
+	public boolean tickScan(BlockGetter reader) {
+		BlockPos originPos = this.origin.atY(reader.getMinBuildHeight());
+		int volume = this.area * reader.getMaxBuildHeight();
+		int march = Mth.ceil((float) volume / Mth.abs(this.scanDurationTicks));
+		int totalProgress = this.ticksProgressed * march;
+
+		for (int scanSteps = 0; scanSteps < march && totalProgress + scanSteps < volume; scanSteps++) {
+			int xDelta = (totalProgress + scanSteps) % this.xSpan;
+			int zDelta = (totalProgress + scanSteps) % (this.xSpan * this.zSpan) / this.xSpan;
+			int yDelta = (totalProgress + scanSteps) / (this.xSpan * this.zSpan);
+
+			BlockPos pos = originPos.offset(xDelta, yDelta, zDelta);
+
+			Block blockFound = reader.getBlockState(pos).getBlock();
+			this.blockCounter.put(blockFound, 1 + this.blockCounter.getOrDefault(blockFound, 0));
+		}
+
+		this.ticksProgressed++;
+
+		// Method returns true if scanning is complete, and results ready for syncing to itemstack nbt
+		return this.ticksProgressed >= this.scanDurationTicks;
+	}
+
+	public Map<String, Integer> getResults(@Nullable String assignedBlock) {
+		if (assignedBlock != null && !assignedBlock.isBlank()) {
+			Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(assignedBlock));
+
+			return ImmutableMap.of(block.getDescriptionId(), this.blockCounter.getOrDefault(block, 0));
+		}
+
+		ImmutableMap.Builder<String, Integer> builder = ImmutableMap.builder();
+
+		for (Object2IntMap.Entry<Block> entry : this.blockCounter.object2IntEntrySet()) {
+			if (entry.getIntValue() > 0 && entry.getKey().builtInRegistryHolder().is(Tags.Blocks.ORES)) {
+				builder.put(entry.getKey().getDescriptionId(), entry.getIntValue());
+			}
+		}
+
+		return builder.build();
+	}
+
+	public int getVolume(BlockGetter reader) {
+		return this.area * reader.getMaxBuildHeight();
+	}
+
+	public int getTickProgress() {
+		return this.ticksProgressed;
+	}
+
+	public ChunkPos centerChunkPos() {
+		return new ChunkPos(Mth.floor(this.origin.getX() + this.xSpan / 2f) >> 4, Mth.floor(this.origin.getZ() + this.zSpan / 2f) >> 4);
+	}
+
+	public boolean isEmpty() {
+		return this.area <= 0;
+	}
+
+	public static OreScannerAttachment getEmpty() {
+		return EMPTY;
+	}
+
+	// This attachment goes onto ItemStacks, so this seems better suited over using a Codec
+	public static class Serializer implements IAttachmentSerializer<CompoundTag, OreScannerAttachment> {
+		public static final OreScannerAttachment.Serializer INSTANCE = new Serializer();
+
+		private Serializer() {
+		}
+
+		@Override
+		public OreScannerAttachment read(IAttachmentHolder holder, CompoundTag tag) {
+			BlockPos origin = NbtUtils.readBlockPos(tag);
+
+			int xSpan = tag.getInt("span_x");
+			int zSpan = tag.getInt("span_z");
+
+			int scanTimeTicks = tag.getInt("duration");
+
+			if (xSpan <= 0 || zSpan <= 0 || scanTimeTicks <= 0) {
+				return EMPTY;
+			}
+
+			OreScannerAttachment attachment = new OreScannerAttachment(origin, xSpan, zSpan, scanTimeTicks);
+
+			ListTag list = tag.getList("counts", 10);
+
+			for (Tag tagEntry : list) {
+				if (tagEntry instanceof CompoundTag compoundEntry) {
+					Block block = BuiltInRegistries.BLOCK.get(ResourceLocation.tryParse(compoundEntry.getString("block")));
+					int counted = compoundEntry.getInt("counted");
+
+					attachment.blockCounter.put(block, counted);
+				}
+			}
+
+			return attachment;
+		}
+
+		@Nullable
+		@Override
+		public CompoundTag write(OreScannerAttachment attachment) {
+			if (attachment.area <= 0)
+				return null;
+
+			CompoundTag tag = NbtUtils.writeBlockPos(attachment.origin);
+
+			tag.putInt("span_x", attachment.xSpan);
+			tag.putInt("span_z", attachment.zSpan);
+
+			tag.putInt("duration", attachment.scanDurationTicks);
+
+			ObjectSet<Object2IntMap.Entry<Block>> scanCounts = attachment.blockCounter.object2IntEntrySet();
+			ListTag list = new ListTag();
+
+			for (Object2IntMap.Entry<Block> counter : scanCounts) {
+				CompoundTag countTag = new CompoundTag();
+
+				countTag.putString("block", BuiltInRegistries.BLOCK.getKey(counter.getKey()).toString());
+				countTag.putInt("counted", counter.getIntValue());
+
+				list.add(countTag);
+			}
+
+			tag.put("counts", list);
+
+			return tag;
+		}
+	}
+}

--- a/src/main/java/twilightforest/client/renderer/TFOverlays.java
+++ b/src/main/java/twilightforest/client/renderer/TFOverlays.java
@@ -148,7 +148,11 @@ public class TFOverlays {
 		);
 
 		ArrayList<ComponentColumn> columns = new ArrayList<>();
-		List<Pair<String, Integer>> scanData = OreMeterItem.getScanInfo(meter).entrySet().stream().map(e -> Pair.of(e.getKey(), e.getValue())).toList();
+
+		List<Pair<String, Integer>> scanData = OreMeterItem.getScanInfo(meter).entrySet().stream()
+				.map(e -> Pair.of(e.getKey(), e.getValue())) // Convert Entries into Pairs
+				.sorted(Comparator.comparing(Pair::getSecond)) // Sort Pairs by second element (quantity)
+				.toList(); // Make sorted immutable list
 
 		if (TFConfig.CLIENT_CONFIG.prettifyOreMeterGui.get()) {
 			ComponentColumn padding = ComponentColumn.padding(1);

--- a/src/main/java/twilightforest/init/TFDataAttachments.java
+++ b/src/main/java/twilightforest/init/TFDataAttachments.java
@@ -6,10 +6,7 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import twilightforest.TwilightForestMod;
-import twilightforest.capabilities.FortificationShieldAttachment;
-import twilightforest.capabilities.GiantPickaxeMiningAttachment;
-import twilightforest.capabilities.PotionFlaskTrackingAttachment;
-import twilightforest.capabilities.YetiThrowAttachment;
+import twilightforest.capabilities.*;
 
 public class TFDataAttachments {
 	public static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES = DeferredRegister.create(NeoForgeRegistries.Keys.ATTACHMENT_TYPES, TwilightForestMod.ID);
@@ -18,5 +15,6 @@ public class TFDataAttachments {
 	public static final DeferredHolder<AttachmentType<?>, AttachmentType<PotionFlaskTrackingAttachment>> FLASK_DOSES = ATTACHMENT_TYPES.register("flask_doses", () -> AttachmentType.builder(PotionFlaskTrackingAttachment::new).serialize(PotionFlaskTrackingAttachment.CODEC).build());
 	public static final DeferredHolder<AttachmentType<?>, AttachmentType<FortificationShieldAttachment>> FORTIFICATION_SHIELDS = ATTACHMENT_TYPES.register("fortification_shields", () -> AttachmentType.builder(FortificationShieldAttachment::new).serialize(FortificationShieldAttachment.CODEC).build());
 	public static final DeferredHolder<AttachmentType<?>, AttachmentType<GiantPickaxeMiningAttachment>> GIANT_PICKAXE_MINING = ATTACHMENT_TYPES.register("giant_pickaxe_mining", () -> AttachmentType.builder(GiantPickaxeMiningAttachment::new).build());
+	public static final DeferredHolder<AttachmentType<?>, AttachmentType<OreScannerAttachment>> ORE_SCANNER = ATTACHMENT_TYPES.register("ore_scanner", () -> AttachmentType.builder(OreScannerAttachment::getEmpty).serialize(OreScannerAttachment.Serializer.INSTANCE).build());
 	public static final DeferredHolder<AttachmentType<?>, AttachmentType<YetiThrowAttachment>> YETI_THROWING = ATTACHMENT_TYPES.register("yeti_throwing", () -> AttachmentType.builder(YetiThrowAttachment::new).build());
 }

--- a/src/main/java/twilightforest/item/OreMeterItem.java
+++ b/src/main/java/twilightforest/item/OreMeterItem.java
@@ -4,6 +4,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
@@ -68,6 +69,10 @@ public class OreMeterItem extends Item {
 	@Override
 	public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
 		ItemStack stack = player.getItemInHand(hand);
+
+		// FakePlayers should never be allowed to use the Ore Meter
+		if (player.getClass() != ServerPlayer.class) return InteractionResultHolder.fail(stack);
+
 		//if we're in the "loading" state don't try to run any logic
 		if (isLoading(stack)) return InteractionResultHolder.pass(stack);
 

--- a/src/main/java/twilightforest/item/OreMeterItem.java
+++ b/src/main/java/twilightforest/item/OreMeterItem.java
@@ -88,7 +88,15 @@ public class OreMeterItem extends Item {
 	private static InteractionResultHolder<ItemStack> beginScanning(Level level, Player player, ItemStack stack) {
 		if (!level.isClientSide) {
 			int range = getRange(stack);
-			OreScannerAttachment data = OreScannerAttachment.scanFromCenter(player.blockPosition(), range, LOAD_TIME);
+
+			// 50 base ticks plus 25 additional ticks for each range increment
+			// Range 0: 50 ticks
+			// Range 1: 75 ticks
+			// Range 2: 100 ticks
+			// It's not an exponent growth to match the increase in chunks, but range is capped at 2 anyway
+			int scanTime = LOAD_TIME + range * 25;
+
+			OreScannerAttachment data = OreScannerAttachment.scanFromCenter(player.blockPosition(), range, scanTime);
 			stack.setData(TFDataAttachments.ORE_SCANNER, data);
 		}
 

--- a/src/main/java/twilightforest/item/OreMeterItem.java
+++ b/src/main/java/twilightforest/item/OreMeterItem.java
@@ -1,14 +1,9 @@
 package twilightforest.item;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
@@ -24,19 +19,18 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.HitResult;
-import net.neoforged.neoforge.common.Tags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import twilightforest.TwilightForestMod;
+import twilightforest.capabilities.OreScannerAttachment;
 import twilightforest.data.tags.BlockTagGenerator;
+import twilightforest.init.TFDataAttachments;
 import twilightforest.init.TFSounds;
 
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class OreMeterItem extends Item {
 	public static final int MAX_CHUNK_SEARCH_RANGE = 2;
@@ -49,21 +43,26 @@ public class OreMeterItem extends Item {
 
 	@Override
 	public void inventoryTick(ItemStack stack, Level level, Entity entity, int slot, boolean held) {
-		//loading logic. The ore meter doesn't display any info until it's been "loading" for 50 ticks.
-		//While mostly a visual thing, this also prevents spamming the meter and constantly populating it with data.
-		CompoundTag scanNbt = getScanData(stack);
-		if (scanNbt != null && scanNbt.contains("Loading") && level.isClientSide()) {
-			int loadTime = scanNbt.getInt("Loading");
-			if (loadTime < LOAD_TIME) {
-				scanNbt.putInt("Loading", loadTime + 1);
-			} else {
-				scanNbt.remove("Loading");
-				int useX = Mth.floor(entity.getX());
-				int useZ = Mth.floor(entity.getZ());
-				String blockId = getAssignedBlock(stack);
-				this.countOreInArea(stack, level, useX, useZ, getRange(stack), blockId != null ? BuiltInRegistries.BLOCK.get(ResourceLocation.tryParse(blockId)) : null);
-			}
+		if (level.isClientSide() || !stack.hasData(TFDataAttachments.ORE_SCANNER)) return;
+
+		OreScannerAttachment data = stack.getData(TFDataAttachments.ORE_SCANNER);
+
+		if (data.isEmpty()) {
+			stack.removeData(TFDataAttachments.ORE_SCANNER);
+			return;
 		}
+
+		if (!data.tickScan(level)) {
+			getOrCreateScanData(stack).putInt("Loading", data.getTickProgress());
+			return;
+		}
+
+		CompoundTag scanData = getScanData(stack);
+		if (scanData != null) scanData.remove("Loading");
+
+		saveScanInfo(stack, data.getResults(getAssignedBlock(stack)), data.centerChunkPos().toLong(), data.getVolume(level));
+
+		stack.removeData(TFDataAttachments.ORE_SCANNER);
 	}
 
 	@Override
@@ -72,28 +71,40 @@ public class OreMeterItem extends Item {
 		//if we're in the "loading" state don't try to run any logic
 		if (isLoading(stack)) return InteractionResultHolder.pass(stack);
 
-		CompoundTag scanNbt = getOrCreateScanData(stack);
-
 		//if we're not crouching, put the ore meter into its "loading" state
 		if (!player.isSecondaryUseActive()) {
-			if (level.isClientSide() && !scanNbt.contains("Loading")) {
-				scanNbt.putInt("Loading", 0);
-			}
-			level.playSound(player, player.blockPosition(), TFSounds.ORE_METER_CRACKLE.get(), SoundSource.PLAYERS, 0.5F, level.getRandom().nextFloat() * 0.1F + 0.9F);
-			return InteractionResultHolder.pass(stack);
+			return beginScanning(level, player, stack);
 		} else {
-			//if we're crouching and not targeting a block, change the ore meter range instead
-			HitResult result = getPlayerPOVHitResult(level, player, ClipContext.Fluid.ANY);
-			if (result.getType() == HitResult.Type.MISS) {
-				int newRange = getRange(stack) + 1;
-				if (newRange > MAX_CHUNK_SEARCH_RANGE) {
-					newRange = 0;
-				}
-				stack.getOrCreateTag().putInt("Range", newRange);
+			return toggleRange(level, player, stack);
+		}
+	}
+
+	@NotNull
+	private static InteractionResultHolder<ItemStack> beginScanning(Level level, Player player, ItemStack stack) {
+		if (!level.isClientSide) {
+			int range = getRange(stack);
+			OreScannerAttachment data = OreScannerAttachment.scanFromCenter(player.blockPosition(), range, LOAD_TIME);
+			stack.setData(TFDataAttachments.ORE_SCANNER, data);
+		}
+
+		level.playSound(player, player.blockPosition(), TFSounds.ORE_METER_CRACKLE.get(), SoundSource.PLAYERS, 0.5F, level.getRandom().nextFloat() * 0.1F + 0.9F);
+
+		return InteractionResultHolder.pass(stack);
+	}
+
+	@NotNull
+	private static InteractionResultHolder<ItemStack> toggleRange(Level level, Player player, ItemStack stack) {
+		//if we're crouching and not targeting a block, change the ore meter range instead
+		HitResult result = getPlayerPOVHitResult(level, player, ClipContext.Fluid.ANY);
+		if (result.getType() == HitResult.Type.MISS) {
+			if (!level.isClientSide) {
+				int newRange = Mth.positiveModulo(getRange(stack) + 1, MAX_CHUNK_SEARCH_RANGE + 1);
+
+				getOrCreateScanData(stack).putInt("Range", newRange);
 				player.displayClientMessage(Component.translatable("misc.twilightforest.ore_meter_new_range", newRange), true);
-				level.playSound(player, player.blockPosition(), SoundEvents.UI_BUTTON_CLICK.value(), SoundSource.PLAYERS, 0.25F, 0.75F + (newRange * 0.1F));
-				return InteractionResultHolder.success(stack);
+				level.playSound(null, player.blockPosition(), SoundEvents.UI_BUTTON_CLICK.value(), SoundSource.PLAYERS, 0.25F, 0.75F + (newRange * 0.1F));
 			}
+			return InteractionResultHolder.success(stack);
 		}
 
 		return InteractionResultHolder.pass(stack);
@@ -106,7 +117,7 @@ public class OreMeterItem extends Item {
 		if (context.isSecondaryUseActive()) {
 			BlockState state = context.getLevel().getBlockState(context.getClickedPos());
 			if (state.is(BlockTagGenerator.ORE_METER_TARGETABLE)) {
-				getScanData(stack).putString("TargetedBlock", BuiltInRegistries.BLOCK.getKey(state.getBlock()).toString());
+				getOrCreateScanData(stack).putString("TargetedBlock", BuiltInRegistries.BLOCK.getKey(state.getBlock()).toString());
 				context.getPlayer().displayClientMessage(Component.translatable("misc.twilightforest.ore_meter_set_block", Component.translatable(state.getBlock().getDescriptionId())), true);
 				context.getLevel().playSound(context.getPlayer(), context.getPlayer().blockPosition(), TFSounds.ORE_METER_TARGET_BLOCK.get(), SoundSource.PLAYERS, 0.5F, context.getLevel().getRandom().nextFloat() * 0.1F + 0.9F);
 				return InteractionResult.SUCCESS;
@@ -218,31 +229,25 @@ public class OreMeterItem extends Item {
 		CompoundTag scanNbt = getScanData(stack);
 
 		if (scanNbt != null && scanNbt.contains("ScanInfo")) {
-			ListTag listTag = scanNbt.getList("ScanInfo", 10);
-			for (Tag tag : listTag) {
-				try {
-					String name = ((CompoundTag) tag).getAllKeys().toArray()[0].toString();
-					tooltips.put(name, ((CompoundTag) tag).getInt(name));
-				} catch (Exception e) {
-					TwilightForestMod.LOGGER.error("Error with deserializing ScanInfo from NBT", e);
-				}
+			CompoundTag listTag = scanNbt.getCompound("ScanInfo");
+			for (var key : listTag.getAllKeys()) {
+				tooltips.put(key, listTag.getInt(key));
 			}
 		}
+
 		return tooltips;
 	}
 
 	public static void saveScanInfo(ItemStack stack, Map<String, Integer> blockInfos, long chunkPos, int totalScanned) {
-		ListTag tag = new ListTag();
-		CompoundTag scanNbt = getOrCreateScanData(stack);
+		CompoundTag blocksCounted = new CompoundTag();
 
-		for (Map.Entry<String, Integer> entry : blockInfos.entrySet()) {
-			CompoundTag compTag = new CompoundTag();
-			compTag.putInt(entry.getKey(), entry.getValue());
-			tag.add(compTag);
+		for (Map.Entry<String, Integer> countEntry : blockInfos.entrySet()) {
+			blocksCounted.putInt(countEntry.getKey(), countEntry.getValue());
 		}
 
-		tag.sort(new TagSorter());
-		scanNbt.put("ScanInfo", tag);
+		CompoundTag scanNbt = getOrCreateScanData(stack);
+		scanNbt.put("ScanInfo", blocksCounted);
+
 		if (chunkPos != 0L) {
 			scanNbt.putLong("ScannedChunk", chunkPos);
 		} else {
@@ -253,88 +258,6 @@ public class OreMeterItem extends Item {
 		} else {
 			scanNbt.remove("ScannedBlocks");
 		}
-		scanNbt.putLong("ID", (tag.hashCode() ^ chunkPos) * (getRange(stack) ^ totalScanned));
-	}
-
-	//note: this is only done client-side to avoid anyone lagging the server.
-	//This information is not synced with the server to prevent sending NBT data, as it could potentially be used maliciously.
-	//the unfortunate side effect of this is that this information will not persist across world reloads
-	private void countOreInArea(ItemStack stack, Level level, int useX, int useZ, int radius, @Nullable Block targetedBlock) {
-		Map<String, Integer> oreCounts = new HashMap<>();
-		int chunkX = useX >> 4;
-		int chunkZ = useZ >> 4;
-
-		ScanResult dummy = new ScanResult();
-		Map<Block, Integer> finalResults = new TreeMap<>(Comparator.comparing(Block::getDescriptionId));
-		AtomicInteger totalScanned = new AtomicInteger();
-		for (int cx = chunkX - radius; cx <= chunkX + radius; cx++) {
-			for (int cz = chunkZ - radius; cz <= chunkZ + radius; cz++) {
-				if (!level.hasChunk(cx, cz)) continue;
-				Map<Block, ScanResult> results = this.countBlocksInChunk(level, cx, cz);
-				results.forEach((state, scanResult) -> totalScanned.addAndGet(scanResult.count));
-				if (targetedBlock != null) {
-					if (results.getOrDefault(targetedBlock, dummy).count != 0) {
-						if (finalResults.containsKey(targetedBlock)) {
-							int existingCount = finalResults.get(targetedBlock);
-							finalResults.put(targetedBlock, results.getOrDefault(targetedBlock, dummy).count + existingCount);
-						} else {
-							finalResults.put(targetedBlock, results.getOrDefault(targetedBlock, dummy).count);
-						}
-					}
-				} else {
-					for (Block block : BuiltInRegistries.BLOCK.getTag(Tags.Blocks.ORES).get().stream().map(Holder::value).toList()) {
-						if (results.getOrDefault(block, dummy).count != 0) {
-							if (finalResults.containsKey(block)) {
-								int existingCount = finalResults.get(block);
-								finalResults.put(block, results.getOrDefault(block, dummy).count + existingCount);
-							} else {
-								finalResults.put(block, results.getOrDefault(block, dummy).count);
-							}
-						}
-					}
-				}
-			}
-		}
-
-
-		if (!finalResults.isEmpty()) {
-			for (Map.Entry<Block, Integer> entry : finalResults.entrySet()) {
-				oreCounts.put(entry.getKey().getDescriptionId(), entry.getValue());
-			}
-		}
-
-		saveScanInfo(stack, oreCounts, new ChunkPos(chunkX, chunkZ).toLong(), totalScanned.get());
-	}
-
-	private Map<Block, ScanResult> countBlocksInChunk(Level level, int cx, int cz) {
-		Map<Block, ScanResult> ret = new IdentityHashMap<>();
-		BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos();
-		for (int x = cx << 4; x < (cx << 4) + 16; x++) {
-			for (int z = cz << 4; z < (cz << 4) + 16; z++) {
-				for (int y = level.getMinBuildHeight(); y < level.getMaxBuildHeight(); y++) {
-					BlockState state = level.getBlockState(pos.set(x, y, z));
-					if (!state.isAir() && !(state.getBlock() instanceof LiquidBlock)) {
-						ScanResult res = ret.computeIfAbsent(state.getBlock(), s -> new ScanResult());
-						res.count++;
-					}
-				}
-			}
-		}
-
-		return ret;
-	}
-
-	private static class ScanResult {
-		int count;
-	}
-
-	public static class TagSorter implements Comparator<Tag> {
-
-		@Override
-		public int compare(Tag o1, Tag o2) {
-			String key1 = (String) ((CompoundTag) o1).getAllKeys().toArray()[0];
-			String key2 = (String) ((CompoundTag) o2).getAllKeys().toArray()[0];
-			return Integer.compare(((CompoundTag) o2).getInt(key2), ((CompoundTag) o1).getInt(key1));
-		}
+		scanNbt.putLong("ID", (blocksCounted.hashCode() ^ chunkPos) * (getRange(stack) ^ totalScanned));
 	}
 }


### PR DESCRIPTION
Scanning of the meter's region is divided across ticks of its waiting time, meaning 1/50 of the impact across 50 ticks instead of a full multi-chunk scan during 1 tick