### PR TITLE
Fix #2029 trophy pedestals for creative players

### DIFF
--- a/src/main/java/twilightforest/block/TrophyPedestalBlock.java
+++ b/src/main/java/twilightforest/block/TrophyPedestalBlock.java
@@ -126,7 +126,7 @@ public class TrophyPedestalBlock extends Block implements SimpleWaterloggedBlock
 	}
 
 	private boolean isPlayerEligible(Player player) {
-		return PlayerHelper.doesPlayerHaveRequiredAdvancements(player, TwilightForestMod.prefix("progress_lich"));
+		return PlayerHelper.doesPlayerHaveRequiredAdvancements(player, TwilightForestMod.prefix("progress_lich")) || player.getAbilities().instabuild;
 	}
 
 	private void doPedestalEffect(Level level, BlockPos pos, BlockState state) {


### PR DESCRIPTION
Make trophy pedestals work for players in creative (they are worthy now)