### PR TITLE
Fix #2030: change PlantType of huge lily pad and huge water lily from PlantType.PLAINS to PlantType.WATER

### DIFF
--- a/src/main/java/twilightforest/block/HugeLilyPadBlock.java
+++ b/src/main/java/twilightforest/block/HugeLilyPadBlock.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.neoforged.neoforge.common.PlantType;
 import twilightforest.enums.HugeLilypadPiece;
 
 import java.util.List;
@@ -88,5 +89,10 @@ public class HugeLilyPadBlock extends WaterlilyBlock {
 		}
 
 		return pieces;
+	}
+
+	@Override
+	public PlantType getPlantType(BlockGetter level, BlockPos pos) {
+		return PlantType.WATER;
 	}
 }

--- a/src/main/java/twilightforest/block/HugeWaterLilyBlock.java
+++ b/src/main/java/twilightforest/block/HugeWaterLilyBlock.java
@@ -7,6 +7,7 @@ import net.minecraft.world.level.block.WaterlilyBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.neoforged.neoforge.common.PlantType;
 
 public class HugeWaterLilyBlock extends WaterlilyBlock {
 
@@ -19,5 +20,10 @@ public class HugeWaterLilyBlock extends WaterlilyBlock {
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter getter, BlockPos pos, CollisionContext context) {
 		return AABB;
+	}
+
+	@Override
+	public PlantType getPlantType(BlockGetter level, BlockPos pos) {
+		return PlantType.WATER;
 	}
 }


### PR DESCRIPTION
Because the huge lily pad and huge water lily had the default IPlantable.getPlantType, which returned PlantType.PLAINS, dirt could be placed under them. I have changed it to return PlantType.WATER.