### PR TITLE
Bugfix: scepters use charges in creative

### DIFF
--- a/src/main/java/twilightforest/item/FortificationWandItem.java
+++ b/src/main/java/twilightforest/item/FortificationWandItem.java
@@ -33,7 +33,7 @@ public class FortificationWandItem extends Item {
 
 		if (!level.isClientSide()) {
 			player.getData(TFDataAttachments.FORTIFICATION_SHIELDS).setShields(player, 5, true);
-			if(player.getAbilities().instabuild) {
+			if(!player.getAbilities().instabuild) {
 				stack.hurtAndBreak(1, level.getRandom(), player, () -> {
 				});
 			}

--- a/src/main/java/twilightforest/item/FortificationWandItem.java
+++ b/src/main/java/twilightforest/item/FortificationWandItem.java
@@ -27,14 +27,16 @@ public class FortificationWandItem extends Item {
 	public InteractionResultHolder<ItemStack> use(Level level, Player player, @Nonnull InteractionHand hand) {
 		ItemStack stack = player.getItemInHand(hand);
 
-		if (stack.getDamageValue() == stack.getMaxDamage()) {
+		if (stack.getDamageValue() == stack.getMaxDamage() && !player.getAbilities().instabuild) {
 			return InteractionResultHolder.fail(stack);
 		}
 
 		if (!level.isClientSide()) {
 			player.getData(TFDataAttachments.FORTIFICATION_SHIELDS).setShields(player, 5, true);
-			stack.hurtAndBreak(1, level.getRandom(), player, () -> {
-			});
+			if(player.getAbilities().instabuild) {
+				stack.hurtAndBreak(1, level.getRandom(), player, () -> {
+				});
+			}
 		}
 		player.playSound(TFSounds.SHIELD_ADD.get(), 1.0F, (player.getRandom().nextFloat() - player.getRandom().nextFloat()) * 0.2F + 1.0F);
 

--- a/src/main/java/twilightforest/item/LifedrainScepterItem.java
+++ b/src/main/java/twilightforest/item/LifedrainScepterItem.java
@@ -180,7 +180,7 @@ public class LifedrainScepterItem extends Item {
 							}
 						}
 
-						if (living instanceof Player player && !player.isCreative()) {
+						if (living instanceof Player player && !player.getAbilities().instabuild) {
 							stack.hurtAndBreak(1, level.getRandom(), player, () -> {
 							});
 						}

--- a/src/main/java/twilightforest/item/LifedrainScepterItem.java
+++ b/src/main/java/twilightforest/item/LifedrainScepterItem.java
@@ -42,7 +42,7 @@ public class LifedrainScepterItem extends Item {
 	public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
 		ItemStack stack = player.getItemInHand(hand);
 
-		if (stack.getDamageValue() == stack.getMaxDamage()) {
+		if (stack.getDamageValue() == stack.getMaxDamage() && !player.getAbilities().instabuild) {
 			return InteractionResultHolder.fail(player.getItemInHand(hand));
 		} else {
 			player.startUsingItem(hand);

--- a/src/main/java/twilightforest/item/TwilightWandItem.java
+++ b/src/main/java/twilightforest/item/TwilightWandItem.java
@@ -25,15 +25,17 @@ public class TwilightWandItem extends Item {
 	public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
 		ItemStack stack = player.getItemInHand(hand);
 
-		if (stack.getDamageValue() == stack.getMaxDamage()) {
+		if (stack.getDamageValue() == stack.getMaxDamage() && !player.getAbilities().instabuild) {
 			return InteractionResultHolder.fail(player.getItemInHand(hand));
 		} else {
 			player.playSound(TFSounds.SCEPTER_PEARL.get(), 1.0F, (level.getRandom().nextFloat() - level.getRandom().nextFloat()) * 0.2F + 1.0F);
 
 			if (!level.isClientSide()) {
 				level.addFreshEntity(new TwilightWandBolt(level, player));
-				stack.hurtAndBreak(1, level.getRandom(), player, () -> {
-				});
+				if (!player.getAbilities().instabuild) {
+					stack.hurtAndBreak(1, level.getRandom(), player, () -> {
+					});
+				}
 			}
 
 			return InteractionResultHolder.success(player.getItemInHand(hand));

--- a/src/main/java/twilightforest/item/ZombieWandItem.java
+++ b/src/main/java/twilightforest/item/ZombieWandItem.java
@@ -33,7 +33,7 @@ public class ZombieWandItem extends Item {
 
 		ItemStack stack = player.getItemInHand(hand);
 
-		if (stack.getDamageValue() == stack.getMaxDamage()) {
+		if (stack.getDamageValue() == stack.getMaxDamage() && !player.getAbilities().instabuild) {
 			return InteractionResultHolder.fail(stack);
 		}
 
@@ -54,8 +54,10 @@ public class ZombieWandItem extends Item {
 				level.addFreshEntity(zombie);
 				level.gameEvent(player, GameEvent.ENTITY_PLACE, result.getBlockPos());
 
-				stack.hurtAndBreak(1, level.getRandom(), player, () -> {
-				});
+				if (!player.getAbilities().instabuild) {
+					stack.hurtAndBreak(1, level.getRandom(), player, () -> {
+					});
+				}
 				zombie.playSound(TFSounds.LOYAL_ZOMBIE_SUMMON.get(), 1.0F, zombie.getVoicePitch());
 			}
 		}


### PR DESCRIPTION
Scepters used charges in creative, and players couldn't use them infinitely. Now, players in creative mode can use them infinitely