### PR TITLE
Bugfix: portals could destroy bedrock or teleport into the void

### DIFF
--- a/src/main/java/twilightforest/world/NoReturnTeleporter.java
+++ b/src/main/java/twilightforest/world/NoReturnTeleporter.java
@@ -53,6 +53,7 @@ public class NoReturnTeleporter extends TFTeleporter {
 		// adjust the portal height based on what world we're traveling to
 		double yFactor = getYFactor(world);
 		// modified copy of base Teleporter method:
-		return makePortalInfo(entity, entity.getX(), (entity.getY() * yFactor) - 1.0, entity.getZ());
+		// + 2 to make it above bedrock
+		return makePortalInfo(entity, entity.getX() * getHorizontalScale(world), (entity.getY() * yFactor) + 2, entity.getZ() * getHorizontalScale(world));
 	}
 }

--- a/src/main/java/twilightforest/world/NoReturnTeleporter.java
+++ b/src/main/java/twilightforest/world/NoReturnTeleporter.java
@@ -28,27 +28,27 @@ public class NoReturnTeleporter extends TFTeleporter {
 		String name = entity.getName().getString();
 
 		if (spot != null) {
-			TwilightForestMod.LOGGER.debug("Found existing portal for {} at {}", name, spot);
+			TwilightForestMod.LOGGER.debug("Found existing teleportation for {} at {}", name, spot);
 			return makePortalInfo(entity, Vec3.atCenterOf(spot.above()));
 		}
 
 		spot = findPortalCoords(world, pos, blockpos -> isIdealForPortal(world, blockpos));
 
 		if (spot != null) {
-			TwilightForestMod.LOGGER.debug("Found ideal portal spot for {} at {}", name, spot);
+			TwilightForestMod.LOGGER.debug("Found ideal teleportation spot for {} at {}", name, spot);
 			return makePortalInfo(entity, Vec3.atCenterOf(spot.above()));
 		}
 
-		TwilightForestMod.LOGGER.debug("Did not find ideal portal spot, shooting for okay one for {}", name);
+		TwilightForestMod.LOGGER.debug("Did not find ideal teleportation spot, shooting for okay one for {}", name);
 		spot = findPortalCoords(world, pos, blockPos -> isOkayForPortal(world, blockPos));
 
 		if (spot != null) {
-			TwilightForestMod.LOGGER.debug("Found okay portal spot for {} at {}", name, spot);
+			TwilightForestMod.LOGGER.debug("Found okay teleportation spot for {} at {}", name, spot);
 			return makePortalInfo(entity, Vec3.atCenterOf(spot.above()));
 		}
 
 		// well I don't think we can actually just return and fail here
-		TwilightForestMod.LOGGER.debug("Did not even find an okay portal spot, just making a random one for {}", name);
+		TwilightForestMod.LOGGER.debug("Did not even find an okay teleportation spot, just making a random one for {}", name);
 
 		// adjust the portal height based on what world we're traveling to
 		double yFactor = getYFactor(world);

--- a/src/main/java/twilightforest/world/TFTeleporter.java
+++ b/src/main/java/twilightforest/world/TFTeleporter.java
@@ -478,7 +478,7 @@ public class TFTeleporter implements ITeleporter {
 	protected static boolean isIdealForPortal(ServerLevel world, BlockPos pos) {
 		for (int potentialZ = 0; potentialZ < 4; potentialZ++) {
 			for (int potentialX = 0; potentialX < 4; potentialX++) {
-				for (int potentialY = -1; potentialY < 6; potentialY++) {
+				for (int potentialY = 0; potentialY < 6; potentialY++) {
 					BlockPos tPos = pos.offset(potentialX - 1, potentialY, potentialZ - 1);
 					BlockState state = world.getBlockState(tPos);
 
@@ -512,13 +512,18 @@ public class TFTeleporter implements ITeleporter {
 		world.setBlockAndUpdate(pos.east().south(2), grass);
 		world.setBlockAndUpdate(pos.east(2).south(2), grass);
 
+		BlockPos[] positions = new BlockPos[4];
+		positions[0] = pos.below();
+		positions[1] = pos.east().below();
+		positions[2] = pos.south().below();
+		positions[3] = pos.east().south().below();
+
 		// dirt under it
 		BlockState dirt = Blocks.DIRT.defaultBlockState();
-
-		world.setBlockAndUpdate(pos.below(), dirt);
-		world.setBlockAndUpdate(pos.east().below(), dirt);
-		world.setBlockAndUpdate(pos.south().below(), dirt);
-		world.setBlockAndUpdate(pos.east().south().below(), dirt);
+		for (BlockPos blockpos: positions) {
+			if(world.getBlockState(pos).is(BlockTags.FEATURES_CANNOT_REPLACE))
+				world.setBlockAndUpdate(blockpos, dirt);
+		}
 
 		// portal in it
 		BlockState portal = TFBlocks.TWILIGHT_PORTAL.get().defaultBlockState().setValue(TFPortalBlock.DISALLOW_RETURN, (this.locked || !TFConfig.shouldReturnPortalBeUsable));
@@ -568,7 +573,7 @@ public class TFTeleporter implements ITeleporter {
 	protected static boolean isOkayForPortal(ServerLevel world, BlockPos pos) {
 		for (int potentialZ = 0; potentialZ < 4; potentialZ++) {
 			for (int potentialX = 0; potentialX < 4; potentialX++) {
-				for (int potentialY = -1; potentialY < 6; potentialY++) {
+				for (int potentialY = 0; potentialY < 6; potentialY++) {
 					BlockPos tPos = pos.offset(potentialX - 1, potentialY, potentialZ - 1);
 					BlockState state = world.getBlockState(tPos);
 
@@ -585,7 +590,7 @@ public class TFTeleporter implements ITeleporter {
 	protected static boolean isOkayForFallbackPortal(ServerLevel world, BlockPos pos) {
 		for (int potentialZ = 0; potentialZ < 4; potentialZ++) {
 			for (int potentialX = 0; potentialX < 4; potentialX++) {
-				for (int potentialY = -1; potentialY < 6; potentialY++) {
+				for (int potentialY = 0; potentialY < 6; potentialY++) {
 					BlockPos tPos = pos.offset(potentialX - 1, potentialY, potentialZ - 1);
 					BlockState state = world.getBlockState(tPos);
 

--- a/src/main/java/twilightforest/world/TFTeleporter.java
+++ b/src/main/java/twilightforest/world/TFTeleporter.java
@@ -152,7 +152,7 @@ public class TFTeleporter implements ITeleporter {
 					continue;
 				}
 
-				for (BlockPos blockpos1 = pos.offset(i1, getScanHeight(destDim, pos) - pos.getY(), j1); blockpos1.getY() >= 0; blockpos1 = blockpos2) {
+				for (BlockPos blockpos1 = pos.offset(i1, getScanHeight(destDim, pos) - pos.getY(), j1); blockpos1.getY() >= destDim.getMinBuildHeight(); blockpos1 = blockpos2) {
 					blockpos2 = blockpos1.below();
 
 					// don't lookup state if inner condition would fail
@@ -541,7 +541,7 @@ public class TFTeleporter implements ITeleporter {
 	protected static boolean isOkayForPortal(ServerLevel world, BlockPos pos) {
 		for (int potentialZ = 0; potentialZ < 4; potentialZ++) {
 			for (int potentialX = 0; potentialX < 4; potentialX++) {
-				for (int potentialY = 0; potentialY < 4; potentialY++) {
+				for (int potentialY = -1; potentialY < 6; potentialY++) {
 					BlockPos tPos = pos.offset(potentialX - 1, potentialY, potentialZ - 1);
 					BlockState state = world.getBlockState(tPos);
 					if (potentialY == 0 && !state.isSolid() && !state.liquid() || potentialY >= 1 && !state.canBeReplaced()) {

--- a/src/main/java/twilightforest/world/TFTeleporter.java
+++ b/src/main/java/twilightforest/world/TFTeleporter.java
@@ -379,8 +379,9 @@ public class TFTeleporter implements ITeleporter {
 
 		// adjust the portal height based on what world we're traveling to
 		double yFactor = getYFactor(world);
-		// modified copy of base Teleporter method:
-		cacheNewPortalCoords(cache, src, this.makePortalAt(world, BlockPos.containing(entity.getX(), (entity.getY() * yFactor) - 1.0, entity.getZ())), entity.blockPosition());
+
+		// + 2 to make it above bedrock
+		cacheNewPortalCoords(cache, src, this.makePortalAt(world, BlockPos.containing(entity.getX() * getHorizontalScale(world), (entity.getY() * yFactor) + 2, entity.getZ() * getHorizontalScale(world))), entity.blockPosition());
 	}
 
 	protected static void loadSurroundingArea(ServerLevel world, Vec3 pos) {

--- a/src/main/java/twilightforest/world/TFTeleporter.java
+++ b/src/main/java/twilightforest/world/TFTeleporter.java
@@ -54,10 +54,7 @@ public class TFTeleporter implements ITeleporter {
 		PortalInfo pos;
 		TeleporterCache cache = TeleporterCache.get(dest);
 
-		// Scale the coords based on the dimension type coordinate_scale
-		ServerLevel tfDim = dest.getServer().getLevel(TFDimension.DIMENSION_KEY);
-		double scale = tfDim == null ? 0.125D : tfDim.dimensionType().coordinateScale();
-		scale = dest.dimension().equals(TFDimension.DIMENSION_KEY) ? 1F / scale : scale;
+		double scale = getHorizontalScale(dest);
 		BlockPos destPos = dest.getWorldBorder().clampToBounds(entity.blockPosition().getX() * scale, entity.blockPosition().getY(), entity.blockPosition().getZ() * scale);
 
 		if ((pos = placeInExistingPortal(cache, dest, entity, destPos)) == null) {
@@ -222,6 +219,13 @@ public class TFTeleporter implements ITeleporter {
 
 	protected static boolean isPortalAt(ServerLevel world, BlockPos pos) {
 		return isPortal(world.getBlockState(pos));
+	}
+
+	// Scale the coords based on the dimension type coordinate_scale
+	protected static double getHorizontalScale(ServerLevel destination) {
+		ServerLevel tfDim = destination.getServer().getLevel(TFDimension.DIMENSION_KEY);
+		double scale = tfDim == null ? 0.125D : tfDim.dimensionType().coordinateScale();
+		return destination.dimension().equals(TFDimension.DIMENSION_KEY) ? 1F / scale : scale;
 	}
 
 	protected static PortalInfo moveToSafeCoords(ServerLevel world, Entity entity, BlockPos pos) {


### PR DESCRIPTION
Portals could break bedrock or teleport into the void. I fixed it.
Before:
Broke bedrock

After:
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/d4d2f676-b6e9-449d-9ffc-ebf5f2fb0254)
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/0fa0490d-726a-4a26-9427-1f63d31d0194)
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/1295c2a4-a751-40fb-88f0-c692f3191666)

Before:
Teleported into the void
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/4dcc79d8-617e-4f10-aaa7-2dcc72726700)


After:
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/59c638c1-304c-45ec-b86f-02710ebc8a40)
