### PR TITLE
Fix: IllegalArgumentException in OreScannerComponent

### DIFF
--- a/src/main/java/twilightforest/components/item/OreScannerComponent.java
+++ b/src/main/java/twilightforest/components/item/OreScannerComponent.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-public class OreScannerComponent  {
+public class OreScannerComponent {
 	public static Codec<OreScannerComponent> CODEC = RecordCodecBuilder.<OreScannerComponent>create(inst -> inst.group(
 		BlockPos.CODEC.fieldOf("origin").forGetter(s -> s.origin),
 		Codec.INT.fieldOf("span_x").forGetter(s -> s.xSpan),

--- a/src/main/java/twilightforest/components/item/OreScannerComponent.java
+++ b/src/main/java/twilightforest/components/item/OreScannerComponent.java
@@ -8,6 +8,8 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.BlockGetter;
@@ -17,9 +19,10 @@ import net.neoforged.neoforge.common.Tags;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
-public class OreScannerComponent {
+public class OreScannerComponent  {
 	public static Codec<OreScannerComponent> CODEC = RecordCodecBuilder.<OreScannerComponent>create(inst -> inst.group(
 		BlockPos.CODEC.fieldOf("origin").forGetter(s -> s.origin),
 		Codec.INT.fieldOf("span_x").forGetter(s -> s.xSpan),
@@ -132,5 +135,31 @@ public class OreScannerComponent {
 
 	public boolean isFinished() {
 		return this.isEmpty() || this.ticksProgressed >= this.scanDurationTicks;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		OreScannerComponent that = (OreScannerComponent) o;
+		return xSpan == that.xSpan && zSpan == that.zSpan && scanDurationTicks == that.scanDurationTicks && ticksProgressed == that.ticksProgressed && Objects.equals(origin, that.origin) && Objects.equals(blockCounter, that.blockCounter);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(xSpan, zSpan, scanDurationTicks, origin, blockCounter, ticksProgressed);
+	}
+
+	@Override
+	public String toString() {
+		return "OreScannerComponent{" +
+			"xSpan=" + xSpan +
+			", zSpan=" + zSpan +
+			", area=" + area +
+			", scanDurationTicks=" + scanDurationTicks +
+			", origin=" + origin +
+			", blockCounter=" + blockCounter +
+			", ticksProgressed=" + ticksProgressed +
+			'}';
 	}
 }


### PR DESCRIPTION
Before:
```
[Server thread/ERROR] [minecraft/ServerPacketListener]: Failed to handle packet net.minecraft.network.protocol.game.ServerboundUseItemPacket@33151411, suppressing error
java.lang.IllegalArgumentException: Data components must implement equals and hashCode. Keep in mind they must also be immutable. Problematic class: class twilightforest.components.item.OreScannerComponent
	at TRANSFORMER/neoforge@20.6.17-beta/net.neoforged.neoforge.common.CommonHooks.validateComponent(CommonHooks.java:1353) ~[neoforge-20.6.17-beta.jar%23203!/:?] {re:classloading}
	at TRANSFORMER/minecraft@1.20.6/net.minecraft.core.component.PatchedDataComponentMap.set(PatchedDataComponentMap.java:67) ~[neoforge-20.6.17-beta.jar%23202!/:?] {re:classloading}
	at TRANSFORMER/minecraft@1.20.6/net.minecraft.world.item.ItemStack.set(ItemStack.java:721) ~[neoforge-20.6.17-beta.jar%23202!/:?] {re:classloading,pl:accesstransformer:B}
	at TRANSFORMER/neoforge@20.6.17-beta/net.neoforged.neoforge.common.MutableDataComponentHolder.set(MutableDataComponentHolder.java:29) ~[neoforge-20.6.17-beta.jar%23203!/:?] {re:classloading}
	at TRANSFORMER/twilightforest@0.0NONE/twilightforest.item.OreMeterItem.beginScanning(OreMeterItem.java:96) ~[%23204!/:?] {re:classloading}
	at TRANSFORMER/twilightforest@0.0NONE/twilightforest.item.OreMeterItem.use(OreMeterItem.java:77) ~[%23204!/:?] {re:classloading}
```

After:
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/1430dc11-e598-4b14-8f86-62d273ae80e5)
