### PR TITLE
Fix bug with canopy trees not spawning on exits of hedge maze

### DIFF
--- a/src/generated/resources/.cache/aceeec62bf10186f98b7c0ef34c2a200449b25e2
+++ b/src/generated/resources/.cache/aceeec62bf10186f98b7c0ef34c2a200449b25e2
@@ -1,4 +1,4 @@
-// 1.20.6	2024-05-06T00:59:12.1596179	Twilight Forest Block Tags
+// 1.20.6	2024-05-19T12:54:47.6458394	Twilight Forest Block Tags
 9d529390443b5da5d71bd6e867c066632e1340b8 data/alexscaves/tags/blocks/ferromagnetic_blocks.json
 ddfcbead67bb9487c003af137a276963e5b20022 data/alexscaves/tags/blocks/gloomoth_light_sources.json
 c365018bd78f1335cd4508b5d74bc4500ae951bd data/alexscaves/tags/blocks/underzealot_light_sources.json
@@ -49,7 +49,7 @@ dfe388780d9d636ad393c72d71b3ff7e0d725c09 data/minecraft/tags/blocks/needs_stone_
 e33c5143db03e28da803a9f265902c39e93589e2 data/minecraft/tags/blocks/overworld_carver_replaceables.json
 54086136e1bef7eed44914bcb6e2822f5846a0a1 data/minecraft/tags/blocks/planks.json
 65049c26c09e844c582a701fe66bd426a58aec5d data/minecraft/tags/blocks/portals.json
-62b29e5d52a53c4b06285db198ddcbda14eddeca data/minecraft/tags/blocks/replaceable_by_trees.json
+a38657626d51e902c764dbfd3de1c7099be2cf90 data/minecraft/tags/blocks/replaceable_by_trees.json
 c1c4b1bbf5dca762f8c2dc1b6021bf08b541ac8f data/minecraft/tags/blocks/saplings.json
 bb39f860aaf80d261eee2fc6cf18ee75a411d1c1 data/minecraft/tags/blocks/slabs.json
 6be3f00e1fa63bb65b978bb8e2c63bbf79b5775e data/minecraft/tags/blocks/small_dripleaf_placeable.json

--- a/src/generated/resources/data/minecraft/tags/blocks/replaceable_by_trees.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/replaceable_by_trees.json
@@ -6,6 +6,7 @@
     "twilightforest:moss_patch",
     "twilightforest:clover_patch",
     "twilightforest:mushgloom",
+    "twilightforest:firefly",
     "twilightforest:fallen_leaves",
     "twilightforest:torchberry_plant",
     "twilightforest:root_strand",

--- a/src/main/java/twilightforest/data/tags/BlockTagGenerator.java
+++ b/src/main/java/twilightforest/data/tags/BlockTagGenerator.java
@@ -237,6 +237,7 @@ public class BlockTagGenerator extends ModdedBlockTagGenerator {
 			TFBlocks.MOSS_PATCH.get(),
 			TFBlocks.CLOVER_PATCH.get(),
 			TFBlocks.MUSHGLOOM.get(),
+			TFBlocks.FIREFLY.get(),
 			TFBlocks.FALLEN_LEAVES.get(),
 			TFBlocks.TORCHBERRY_PLANT.get(),
 			TFBlocks.ROOT_STRAND.get(),


### PR DESCRIPTION
Before:
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/8c15d469-b36b-4942-beb3-fc37f9204c36)

After:
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/dd40521e-de2e-43ba-add5-0ec372fc3553)