### PR TITLE
Add #2044: add shield overlay to players in creative.

### DIFF
--- a/src/main/java/twilightforest/client/renderer/TFOverlays.java
+++ b/src/main/java/twilightforest/client/renderer/TFOverlays.java
@@ -80,7 +80,7 @@ public class TFOverlays {
 			Minecraft minecraft = Minecraft.getInstance();
 			LocalPlayer player = minecraft.player;
 			Gui gui = minecraft.gui;
-			if (player != null && !minecraft.options.hideGui && minecraft.gameMode.canHurtPlayer() && player.hasData(TFDataAttachments.FORTIFICATION_SHIELDS) && player.getData(TFDataAttachments.FORTIFICATION_SHIELDS).shieldsLeft() > 0 && TFConfig.showFortificationShieldIndicator) {
+			if (player != null && !minecraft.options.hideGui && (minecraft.gameMode.canHurtPlayer() || TFConfig.showFortificationShieldIndicatorInCreative) && player.hasData(TFDataAttachments.FORTIFICATION_SHIELDS) && player.getData(TFDataAttachments.FORTIFICATION_SHIELDS).shieldsLeft() > 0 && TFConfig.showFortificationShieldIndicator) {
 				renderShieldCount(graphics, gui, player, graphics.guiWidth(), graphics.guiHeight(), player.getData(TFDataAttachments.FORTIFICATION_SHIELDS).shieldsLeft());
 			}
 		});

--- a/src/main/java/twilightforest/config/TFClientConfig.java
+++ b/src/main/java/twilightforest/config/TFClientConfig.java
@@ -15,6 +15,7 @@ public class TFClientConfig {
 	final ModConfigSpec.BooleanValue disableLockedBiomeToasts;
 	final ModConfigSpec.BooleanValue showQuestRamCrosshairIndicator;
 	final ModConfigSpec.BooleanValue showFortificationShieldIndicator;
+	final ModConfigSpec.BooleanValue showFortificationShieldIndicatorInCreative;
 	final ModConfigSpec.IntValue cloudBlockPrecipitationDistance;
 	final ModConfigSpec.ConfigValue<List<? extends String>> giantSkinUUIDs;
 	final ModConfigSpec.ConfigValue<List<? extends String>> auroraBiomes;
@@ -61,6 +62,11 @@ public class TFClientConfig {
 			.translation(TFConfig.CONFIG_ID + "shield_indicator")
 			.comment("Renders how many fortification shields are currently active on your player above your armor bar. Turn this off if you find it intrusive or other mods render over/under it.")
 			.define("fortificationShieldIndicator", true);
+
+		showFortificationShieldIndicatorInCreative = builder
+			.translation(TFConfig.CONFIG_ID + "shield_indicator_creative")
+			.comment("Enables shield indicator in creative for debugging.")
+			.define("fortificationShieldIndicatorInCreative", false);
 
 		cloudBlockPrecipitationDistance = builder
 			.translation(TFConfig.CONFIG_ID + "cloud_block_precipitation_distance")

--- a/src/main/java/twilightforest/config/TFClientConfig.java
+++ b/src/main/java/twilightforest/config/TFClientConfig.java
@@ -65,7 +65,7 @@ public class TFClientConfig {
 
 		showFortificationShieldIndicatorInCreative = builder
 			.translation(TFConfig.CONFIG_ID + "shield_indicator_creative")
-			.comment("Enables shield indicator in creative for debugging.")
+			.comment("Enables fortification shield indicator in creative for debugging.")
 			.define("fortificationShieldIndicatorInCreative", false);
 
 		cloudBlockPrecipitationDistance = builder

--- a/src/main/java/twilightforest/config/TFConfig.java
+++ b/src/main/java/twilightforest/config/TFConfig.java
@@ -39,6 +39,7 @@ public class TFConfig {
 	public static boolean disableLockedBiomeToasts = false;
 	public static boolean showQuestRamCrosshairIndicator = true;
 	public static boolean showFortificationShieldIndicator = true;
+	public static boolean showFortificationShieldIndicatorInCreative = false;
 	private static int clientCloudBlockPrecipitationDistance = 32;
 	public static boolean prettifyOreMeterGui = true;
 	public static boolean spawnCharmAnimationAsTotem = false;
@@ -200,6 +201,7 @@ public class TFConfig {
 		disableOptifineNagScreen = config.disableOptifineNagScreen.get();
 		disableLockedBiomeToasts = config.disableLockedBiomeToasts.get();
 		showFortificationShieldIndicator = config.showFortificationShieldIndicator.get();
+		showFortificationShieldIndicatorInCreative = config.showFortificationShieldIndicatorInCreative.get();
 		showQuestRamCrosshairIndicator = config.showQuestRamCrosshairIndicator.get();
 		clientCloudBlockPrecipitationDistance = config.cloudBlockPrecipitationDistance.get();
 		prettifyOreMeterGui = config.prettifyOreMeterGui.get();

--- a/src/main/java/twilightforest/events/CapabilityEvents.java
+++ b/src/main/java/twilightforest/events/CapabilityEvents.java
@@ -49,7 +49,6 @@ public class CapabilityEvents {
 	public static void livingAttack(LivingAttackEvent event) {
 		LivingEntity living = event.getEntity();
 		// shields
-		if (event.getEntity() instanceof Player player && player.getAbilities().invulnerable) return;
 		if (!living.level().isClientSide() && !event.getSource().is(DamageTypeTags.BYPASSES_ARMOR)) {
 			var attachment = living.getData(TFDataAttachments.FORTIFICATION_SHIELDS);
 			if (attachment.shieldsLeft() > 0) {


### PR DESCRIPTION
Creative players couldn't see how many shields they have without using F5. Now, there is a config option that allows the shield overlay to be displayed in creative mode. Shields can also be broken in Creative mode now.
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/7fadf454-0161-4697-8db1-6cefccff531a)