### PR TITLE
Fix bug where mobs didn't have heads

### DIFF
--- a/src/main/java/twilightforest/client/TFClientEvents.java
+++ b/src/main/java/twilightforest/client/TFClientEvents.java
@@ -475,10 +475,10 @@ public class TFClientEvents {
 		ItemStack stack = event.getEntity().getItemBySlot(EquipmentSlot.HEAD);
 		boolean visible = !(stack.getItem() instanceof TrophyItem) && !(stack.getItem() instanceof SkullCandleItem) && !areCuriosEquipped(event.getEntity());
 
-		if (!visible && event.getRenderer().getModel() instanceof HeadedModel headedModel) {
-			headedModel.getHead().visible = false;
+		if (event.getRenderer().getModel() instanceof HeadedModel headedModel) {
+			headedModel.getHead().visible = visible;
 			if (event.getRenderer().getModel() instanceof HumanoidModel<?> humanoidModel) {
-				humanoidModel.hat.visible = false;
+				humanoidModel.hat.visible = visible;
 			}
 		}
 	}


### PR DESCRIPTION
**How to reproduce the bug:**
1. Spawn a mob with any trophy on its head. 
2. Spawn the same mob without the trophy.

Before:
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/0174242c-5a08-4389-8015-4aacd2df5d61)

After:
![image](https://github.com/TeamTwilight/twilightforest/assets/97367938/789b38d1-fc97-42e9-8f1c-9740b70384ec)


**Another Solution:**
Rewrite the trophy class to extend the skull class.