### PR TITLE
Fix portal overlay not rendering

### DIFF
--- a/src/main/java/twilightforest/block/TFPortalBlock.java
+++ b/src/main/java/twilightforest/block/TFPortalBlock.java
@@ -44,6 +44,7 @@ import org.jetbrains.annotations.Nullable;
 import twilightforest.config.TFConfig;
 import twilightforest.data.tags.BlockTagGenerator;
 import twilightforest.init.TFBlocks;
+import twilightforest.init.TFDataAttachments;
 import twilightforest.init.TFDimension;
 import twilightforest.init.TFSounds;
 import twilightforest.network.MissingAdvancementToastPacket;
@@ -235,6 +236,7 @@ public class TFPortalBlock extends HalfTransparentBlock implements LiquidBlockCo
 				entity.setAsInsidePortal(this, entity.blockPosition());
 			}
 		}
+		entity.getData(TFDataAttachments.TF_PORTAL_COOLDOWN).setInPortal(true);
 	}
 
 	public static boolean isPlayerNotifiedOfRequirement(ServerPlayer player) {


### PR DESCRIPTION
This PR returns the twilight forest portal overlay effect.

Before:
![image](https://github.com/user-attachments/assets/3cccd60c-40b9-4f84-a8e6-318082155896)

After:
![image](https://github.com/user-attachments/assets/a90c241e-5cdb-4694-98b4-4cdbbbffdd8b)

This PR requires approval from @GizmoTheMoonPig because I don't know why he removed this line of code.
Thanks to Alyaqdhan for finding this issue.