### PR TITLE
Additional Crumble Horn Recipes

### DIFF
--- a/src/generated/resources/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
+++ b/src/generated/resources/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
@@ -1,8 +1,8 @@
-// 1.21.1	2024-08-26T03:54:37.2144051	Data Maps
+// 1.21.1	2024-08-26T03:59:02.8634427	Data Maps
 9d605f77607fab46af7ad213ed8d31788a2321c9 data/neoforge/data_maps/entity_type/parrot_imitations.json
 afd96f81ddd677bc5552b0685df897a93f4d6445 data/neoforge/data_maps/item/compostables.json
 1bda341a4fd3cfbd09ba74b7072ce0931799b473 data/neoforge/data_maps/item/furnace_fuels.json
-e5a7f23698d150effadd0bfefbfa56785468baf1 data/twilightforest/data_maps/block/crumble_horn.json
+c108bbdfd17387a351e0300f6c145de405721544 data/twilightforest/data_maps/block/crumble_horn.json
 7250563057afb29996423871be69f9cd4f78b7cc data/twilightforest/data_maps/block/ore_map_color.json
 f5a5270de0e2efc94735b1807a6d8ee6e27984cd data/twilightforest/data_maps/entity_type/transformation_powder.json
 1e9abba89255dd095b06fe297a834f1bad141a5b data/twilightforest/data_maps/worldgen/biome/magic_map_color.json

--- a/src/generated/resources/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
+++ b/src/generated/resources/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
@@ -1,8 +1,8 @@
-// 1.21.1	2024-08-26T03:59:02.8634427	Data Maps
+// 1.21.1	2024-08-26T04:01:24.0420812	Data Maps
 9d605f77607fab46af7ad213ed8d31788a2321c9 data/neoforge/data_maps/entity_type/parrot_imitations.json
 afd96f81ddd677bc5552b0685df897a93f4d6445 data/neoforge/data_maps/item/compostables.json
 1bda341a4fd3cfbd09ba74b7072ce0931799b473 data/neoforge/data_maps/item/furnace_fuels.json
-c108bbdfd17387a351e0300f6c145de405721544 data/twilightforest/data_maps/block/crumble_horn.json
+8a5b0485a5ac296217fe1f69fc34d7126e5ca4c9 data/twilightforest/data_maps/block/crumble_horn.json
 7250563057afb29996423871be69f9cd4f78b7cc data/twilightforest/data_maps/block/ore_map_color.json
 f5a5270de0e2efc94735b1807a6d8ee6e27984cd data/twilightforest/data_maps/entity_type/transformation_powder.json
 1e9abba89255dd095b06fe297a834f1bad141a5b data/twilightforest/data_maps/worldgen/biome/magic_map_color.json

--- a/src/generated/resources/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
+++ b/src/generated/resources/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
@@ -1,8 +1,8 @@
-// 1.21.1	2024-08-11T11:15:17.210403902	Data Maps
+// 1.21.1	2024-08-26T03:54:37.2144051	Data Maps
 9d605f77607fab46af7ad213ed8d31788a2321c9 data/neoforge/data_maps/entity_type/parrot_imitations.json
 afd96f81ddd677bc5552b0685df897a93f4d6445 data/neoforge/data_maps/item/compostables.json
 1bda341a4fd3cfbd09ba74b7072ce0931799b473 data/neoforge/data_maps/item/furnace_fuels.json
-259a41c8060b051c413b372cfa45bfc4061cc228 data/twilightforest/data_maps/block/crumble_horn.json
+e5a7f23698d150effadd0bfefbfa56785468baf1 data/twilightforest/data_maps/block/crumble_horn.json
 7250563057afb29996423871be69f9cd4f78b7cc data/twilightforest/data_maps/block/ore_map_color.json
 f5a5270de0e2efc94735b1807a6d8ee6e27984cd data/twilightforest/data_maps/entity_type/transformation_powder.json
 1e9abba89255dd095b06fe297a834f1bad141a5b data/twilightforest/data_maps/worldgen/biome/magic_map_color.json

--- a/src/generated/resources/data/twilightforest/data_maps/block/crumble_horn.json
+++ b/src/generated/resources/data/twilightforest/data_maps/block/crumble_horn.json
@@ -48,9 +48,17 @@
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:copper_bulb"
     },
+    "minecraft:exposed_copper_door": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:copper_door"
+    },
     "minecraft:exposed_copper_grate": {
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:copper_grate"
+    },
+    "minecraft:exposed_copper_trapdoor": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:copper_trapdoor"
     },
     "minecraft:exposed_cut_copper": {
       "crumble_chance": 0.2,
@@ -92,9 +100,17 @@
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:weathered_copper_bulb"
     },
+    "minecraft:oxidized_copper_door": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:weathered_copper_door"
+    },
     "minecraft:oxidized_copper_grate": {
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:weathered_copper_grate"
+    },
+    "minecraft:oxidized_copper_trapdoor": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:weathered_copper_trapdoor"
     },
     "minecraft:oxidized_cut_copper": {
       "crumble_chance": 0.2,
@@ -148,9 +164,17 @@
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:exposed_copper_bulb"
     },
+    "minecraft:weathered_copper_door": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:exposed_copper_door"
+    },
     "minecraft:weathered_copper_grate": {
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:exposed_copper_grate"
+    },
+    "minecraft:weathered_copper_trapdoor": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:exposed_copper_trapdoor"
     },
     "minecraft:weathered_cut_copper": {
       "crumble_chance": 0.2,

--- a/src/generated/resources/data/twilightforest/data_maps/block/crumble_horn.json
+++ b/src/generated/resources/data/twilightforest/data_maps/block/crumble_horn.json
@@ -36,9 +36,21 @@
       "crumble_chance": 0.05,
       "crumble_to": "minecraft:air"
     },
+    "minecraft:exposed_chiseled_copper": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:chiseled_copper"
+    },
     "minecraft:exposed_copper": {
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:copper_block"
+    },
+    "minecraft:exposed_copper_bulb": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:copper_bulb"
+    },
+    "minecraft:exposed_copper_grate": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:copper_grate"
     },
     "minecraft:exposed_cut_copper": {
       "crumble_chance": 0.2,
@@ -68,9 +80,21 @@
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:cracked_nether_bricks"
     },
+    "minecraft:oxidized_chiseled_copper": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:weathered_chiseled_copper"
+    },
     "minecraft:oxidized_copper": {
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:weathered_copper"
+    },
+    "minecraft:oxidized_copper_bulb": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:weathered_copper_bulb"
+    },
+    "minecraft:oxidized_copper_grate": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:weathered_copper_grate"
     },
     "minecraft:oxidized_cut_copper": {
       "crumble_chance": 0.2,
@@ -112,9 +136,21 @@
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:cracked_stone_bricks"
     },
+    "minecraft:weathered_chiseled_copper": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:exposed_chiseled_copper"
+    },
     "minecraft:weathered_copper": {
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:exposed_copper"
+    },
+    "minecraft:weathered_copper_bulb": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:exposed_copper_bulb"
+    },
+    "minecraft:weathered_copper_grate": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:exposed_copper_grate"
     },
     "minecraft:weathered_cut_copper": {
       "crumble_chance": 0.2,

--- a/src/generated/resources/data/twilightforest/data_maps/block/crumble_horn.json
+++ b/src/generated/resources/data/twilightforest/data_maps/block/crumble_horn.json
@@ -64,6 +64,14 @@
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:cut_copper"
     },
+    "minecraft:exposed_cut_copper_slab": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:cut_copper_slab"
+    },
+    "minecraft:exposed_cut_copper_stairs": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:cut_copper_stairs"
+    },
     "minecraft:granite": {
       "crumble_chance": 0.05,
       "crumble_to": "minecraft:air"
@@ -115,6 +123,14 @@
     "minecraft:oxidized_cut_copper": {
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:weathered_cut_copper"
+    },
+    "minecraft:oxidized_cut_copper_slab": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:weathered_cut_copper_slab"
+    },
+    "minecraft:oxidized_cut_copper_stairs": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:weathered_cut_copper_stairs"
     },
     "minecraft:podzol": {
       "crumble_chance": 0.2,
@@ -179,6 +195,14 @@
     "minecraft:weathered_cut_copper": {
       "crumble_chance": 0.2,
       "crumble_to": "minecraft:exposed_cut_copper"
+    },
+    "minecraft:weathered_cut_copper_slab": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:exposed_cut_copper_slab"
+    },
+    "minecraft:weathered_cut_copper_stairs": {
+      "crumble_chance": 0.2,
+      "crumble_to": "minecraft:exposed_cut_copper_stairs"
     },
     "twilightforest:castle_brick": {
       "crumble_chance": 0.2,

--- a/src/main/java/twilightforest/data/DataMapGenerator.java
+++ b/src/main/java/twilightforest/data/DataMapGenerator.java
@@ -176,6 +176,12 @@ public class DataMapGenerator extends DataMapProvider {
 		crumble.add(Blocks.OXIDIZED_CUT_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_CUT_COPPER, 0.2F), false);
 		crumble.add(Blocks.WEATHERED_CUT_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_CUT_COPPER, 0.2F), false);
 		crumble.add(Blocks.EXPOSED_CUT_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.CUT_COPPER, 0.2F), false);
+		crumble.add(Blocks.OXIDIZED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_CUT_COPPER_STAIRS, 0.2F), false);
+		crumble.add(Blocks.WEATHERED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_CUT_COPPER_STAIRS, 0.2F), false);
+		crumble.add(Blocks.EXPOSED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new CrumbledBlock(Blocks.CUT_COPPER_STAIRS, 0.2F), false);
+		crumble.add(Blocks.OXIDIZED_CUT_COPPER_SLAB.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_CUT_COPPER_SLAB, 0.2F), false);
+		crumble.add(Blocks.WEATHERED_CUT_COPPER_SLAB.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_CUT_COPPER_SLAB, 0.2F), false);
+		crumble.add(Blocks.EXPOSED_CUT_COPPER_SLAB.builtInRegistryHolder(), new CrumbledBlock(Blocks.CUT_COPPER_SLAB, 0.2F), false);
 		crumble.add(Blocks.OXIDIZED_CHISELED_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_CHISELED_COPPER, 0.2F), false);
 		crumble.add(Blocks.WEATHERED_CHISELED_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_CHISELED_COPPER, 0.2F), false);
 		crumble.add(Blocks.EXPOSED_CHISELED_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.CHISELED_COPPER, 0.2F), false);

--- a/src/main/java/twilightforest/data/DataMapGenerator.java
+++ b/src/main/java/twilightforest/data/DataMapGenerator.java
@@ -176,6 +176,15 @@ public class DataMapGenerator extends DataMapProvider {
 		crumble.add(Blocks.OXIDIZED_CUT_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_CUT_COPPER, 0.2F), false);
 		crumble.add(Blocks.WEATHERED_CUT_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_CUT_COPPER, 0.2F), false);
 		crumble.add(Blocks.EXPOSED_CUT_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.CUT_COPPER, 0.2F), false);
+		crumble.add(Blocks.OXIDIZED_CHISELED_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_CHISELED_COPPER, 0.2F), false);
+		crumble.add(Blocks.WEATHERED_CHISELED_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_CHISELED_COPPER, 0.2F), false);
+		crumble.add(Blocks.EXPOSED_CHISELED_COPPER.builtInRegistryHolder(), new CrumbledBlock(Blocks.CHISELED_COPPER, 0.2F), false);
+		crumble.add(Blocks.OXIDIZED_COPPER_GRATE.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_COPPER_GRATE, 0.2F), false);
+		crumble.add(Blocks.WEATHERED_COPPER_GRATE.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_COPPER_GRATE, 0.2F), false);
+		crumble.add(Blocks.EXPOSED_COPPER_GRATE.builtInRegistryHolder(), new CrumbledBlock(Blocks.COPPER_GRATE, 0.2F), false);
+		crumble.add(Blocks.OXIDIZED_COPPER_BULB.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_COPPER_BULB, 0.2F), false);
+		crumble.add(Blocks.WEATHERED_COPPER_BULB.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_COPPER_BULB, 0.2F), false);
+		crumble.add(Blocks.EXPOSED_COPPER_BULB.builtInRegistryHolder(), new CrumbledBlock(Blocks.COPPER_BULB, 0.2F), false);
 		crumble.add(Blocks.GRAVEL.builtInRegistryHolder(), new CrumbledBlock(Blocks.AIR, 0.05F), false);
 		crumble.add(Blocks.DIRT.builtInRegistryHolder(), new CrumbledBlock(Blocks.AIR, 0.05F), false);
 		crumble.add(Blocks.SAND.builtInRegistryHolder(), new CrumbledBlock(Blocks.AIR, 0.05F), false);

--- a/src/main/java/twilightforest/data/DataMapGenerator.java
+++ b/src/main/java/twilightforest/data/DataMapGenerator.java
@@ -185,6 +185,12 @@ public class DataMapGenerator extends DataMapProvider {
 		crumble.add(Blocks.OXIDIZED_COPPER_BULB.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_COPPER_BULB, 0.2F), false);
 		crumble.add(Blocks.WEATHERED_COPPER_BULB.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_COPPER_BULB, 0.2F), false);
 		crumble.add(Blocks.EXPOSED_COPPER_BULB.builtInRegistryHolder(), new CrumbledBlock(Blocks.COPPER_BULB, 0.2F), false);
+		crumble.add(Blocks.OXIDIZED_COPPER_TRAPDOOR.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_COPPER_TRAPDOOR, 0.2F), false);
+		crumble.add(Blocks.WEATHERED_COPPER_TRAPDOOR.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_COPPER_TRAPDOOR, 0.2F), false);
+		crumble.add(Blocks.EXPOSED_COPPER_TRAPDOOR.builtInRegistryHolder(), new CrumbledBlock(Blocks.COPPER_TRAPDOOR, 0.2F), false);
+		crumble.add(Blocks.OXIDIZED_COPPER_DOOR.builtInRegistryHolder(), new CrumbledBlock(Blocks.WEATHERED_COPPER_DOOR, 0.2F), false);
+		crumble.add(Blocks.WEATHERED_COPPER_DOOR.builtInRegistryHolder(), new CrumbledBlock(Blocks.EXPOSED_COPPER_DOOR, 0.2F), false);
+		crumble.add(Blocks.EXPOSED_COPPER_DOOR.builtInRegistryHolder(), new CrumbledBlock(Blocks.COPPER_DOOR, 0.2F), false);
 		crumble.add(Blocks.GRAVEL.builtInRegistryHolder(), new CrumbledBlock(Blocks.AIR, 0.05F), false);
 		crumble.add(Blocks.DIRT.builtInRegistryHolder(), new CrumbledBlock(Blocks.AIR, 0.05F), false);
 		crumble.add(Blocks.SAND.builtInRegistryHolder(), new CrumbledBlock(Blocks.AIR, 0.05F), false);


### PR DESCRIPTION
This is a PR to add Crumble Horn recipes to the new 1.21 Copper blocks. I also noticed that the 1.17 cut copper stairs/slabs were not given Crumble Horn recipes, so I added those here as well in the case these were forgotten.

This PR is divided into 3 segments:
- The new 1.21 chiseled copper, copper bulb, and copper grates
- The new 1.21 copper door and trapdoors
- The old 1.17 cut copper stairs and slabs

If you want to cherry-pick which group of new blocks you want to add Crumbling recipes for, you are more than welcome to do so. I figured to just do all of the copper stuff together in 1 PR to save time.

