### PR TITLE
[1.20.1] Fix missing comma in ja_jp.json

### DIFF
--- a/src/main/resources/assets/twilightforest/lang/ja_jp.json
+++ b/src/main/resources/assets/twilightforest/lang/ja_jp.json
@@ -1004,7 +1004,7 @@
   "block.twilightforest.bold_castle_brick_tile": "太いキャッスルレンガ",
   "block.twilightforest.pink_castle_rune_brick": "ルーンレンガ(赤紫)",
   "block.twilightforest.pink_castle_door": "キャッスルドア(赤紫)",
-  "block.twilightforest.pink_force_field": "フォースフィールド(赤紫)"
+  "block.twilightforest.pink_force_field": "フォースフィールド(赤紫)",
   "itemGroup.twilightforest.blocks": "黄昏の森: ブロック",
   "itemGroup.twilightforest.equipment": "黄昏の森: 装備",
   "itemGroup.twilightforest.items": "黄昏の森: アイテム",


### PR DESCRIPTION
This problem fixed by #1956 in 1.20.2 and above, but it still exists only in 1.20.1.