### PR TITLE
Fix issue #2399: Custom Arrow Entities Don't Inherit Arrow Effects

### DIFF
--- a/src/main/java/twilightforest/entity/projectile/IceArrow.java
+++ b/src/main/java/twilightforest/entity/projectile/IceArrow.java
@@ -5,6 +5,7 @@ import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.projectile.AbstractArrow;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
@@ -22,6 +23,10 @@ public class IceArrow extends TFArrow {
 
 	public IceArrow(Level world, @Nullable LivingEntity shooter, ItemStack stack, ItemStack weapon) {
 		super(TFEntities.ICE_ARROW.get(), world, shooter, stack, weapon);
+	}
+
+	public IceArrow(AbstractArrow parentArrow, ItemStack stack, ItemStack weapon) {
+		super(TFEntities.ICE_ARROW.get(), parentArrow, stack, weapon);
 	}
 
 	@Override

--- a/src/main/java/twilightforest/entity/projectile/SeekerArrow.java
+++ b/src/main/java/twilightforest/entity/projectile/SeekerArrow.java
@@ -6,6 +6,7 @@ import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.monster.Monster;
+import net.minecraft.world.entity.projectile.AbstractArrow;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
@@ -32,6 +33,11 @@ public class SeekerArrow extends TFArrow {
 
 	public SeekerArrow(Level world, LivingEntity shooter, ItemStack stack, ItemStack weapon) {
 		super(TFEntities.SEEKER_ARROW.get(), world, shooter, stack, weapon);
+		this.setBaseDamage(1.0D);
+	}
+
+	public SeekerArrow(AbstractArrow parentArrow, ItemStack stack, ItemStack weapon) {
+		super(TFEntities.SEEKER_ARROW.get(), parentArrow, stack, weapon);
 		this.setBaseDamage(1.0D);
 	}
 

--- a/src/main/java/twilightforest/entity/projectile/TFArrow.java
+++ b/src/main/java/twilightforest/entity/projectile/TFArrow.java
@@ -11,8 +11,12 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class TFArrow extends AbstractArrow implements ITFProjectile {
 
+	@Nullable
+	protected final AbstractArrow parentArrow;
+
 	public TFArrow(EntityType<? extends TFArrow> type, Level level) {
 		super(type, level);
+		this.parentArrow = null;
 	}
 
 	public TFArrow(EntityType<? extends TFArrow> type, Level level, @Nullable LivingEntity shooter, ItemStack stack, ItemStack weapon) {
@@ -21,10 +25,29 @@ public abstract class TFArrow extends AbstractArrow implements ITFProjectile {
 		if (shooter != null) {
 			this.setPos(shooter.getX(), shooter.getEyeY() - 0.1D, shooter.getZ());
 		}
+		this.parentArrow = null;
+	}
+
+	public TFArrow(EntityType<? extends TFArrow> type, AbstractArrow parentArrow, ItemStack stack, ItemStack weapon) {
+		super(type, (LivingEntity) parentArrow.getOwner(), parentArrow.level(), stack, weapon);
+		var shooter = (LivingEntity) parentArrow.getOwner();
+		this.setOwner(shooter);
+		if (shooter != null) {
+			this.setPos(shooter.getX(), shooter.getEyeY() - 0.1D, shooter.getZ());
+		}
+		this.parentArrow = parentArrow;
 	}
 
 	@Override
 	protected ItemStack getDefaultPickupItem() {
 		return new ItemStack(Items.ARROW);
+	}
+
+	@Override
+	public void doPostHurtEffects(LivingEntity target) {
+		if (this.parentArrow != null) {
+			this.parentArrow.doPostHurtEffects(target);
+		}
+		super.doPostHurtEffects(target);
 	}
 }

--- a/src/main/java/twilightforest/item/IceBowItem.java
+++ b/src/main/java/twilightforest/item/IceBowItem.java
@@ -14,6 +14,6 @@ public class IceBowItem extends BowItem {
 
 	@Override
 	public AbstractArrow customArrow(AbstractArrow arrow, ItemStack projectileStack, ItemStack weaponStack) {
-		return new IceArrow(arrow.level(), (LivingEntity) arrow.getOwner(), projectileStack.copyWithCount(1), weaponStack);
+		return new IceArrow(arrow, projectileStack.copyWithCount(1), weaponStack);
 	}
 }

--- a/src/main/java/twilightforest/item/SeekerBowItem.java
+++ b/src/main/java/twilightforest/item/SeekerBowItem.java
@@ -14,6 +14,6 @@ public class SeekerBowItem extends BowItem {
 
 	@Override
 	public AbstractArrow customArrow(AbstractArrow arrow, ItemStack projectileStack, ItemStack weaponStack) {
-		return new SeekerArrow(arrow.level(), (LivingEntity) arrow.getOwner(), projectileStack.copyWithCount(1), weaponStack);
+		return new SeekerArrow(arrow, projectileStack.copyWithCount(1), weaponStack);
 	}
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -255,3 +255,8 @@ public net.minecraft.world.item.BlockItem updateBlockEntityComponents(Lnet/minec
 
 public net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer renderArmorPiece(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/EquipmentSlot;ILnet/minecraft/client/model/HumanoidModel;)V
 public net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer getArmorModel(Lnet/minecraft/client/renderer/entity/state/HumanoidRenderState;Lnet/minecraft/world/entity/EquipmentSlot;)Lnet/minecraft/client/model/HumanoidModel;
+
+# TFArrow (add the effects of the original arrow to target entity)
+public net.minecraft.world.entity.projectile.AbstractArrow doPostHurtEffects(Lnet/minecraft/world/entity/LivingEntity;)V
+public net.minecraft.world.entity.projectile.Arrow doPostHurtEffects(Lnet/minecraft/world/entity/LivingEntity;)V
+public net.minecraft.world.entity.projectile.SpectralArrow doPostHurtEffects(Lnet/minecraft/world/entity/LivingEntity;)V


### PR DESCRIPTION
This update makes IceBow and SeekerBow add the extra effect from arrow to the target entity. 