### PR TITLE
Prevent crash when placing TrollsteinnBlock on dedicated server

### DIFF
--- a/src/main/java/twilightforest/block/TrollsteinnBlock.java
+++ b/src/main/java/twilightforest/block/TrollsteinnBlock.java
@@ -47,7 +47,7 @@ public class TrollsteinnBlock extends Block {
 	/**
 	 * Computation from vanilla function updateSkyBrightness in Level.java
 	 */
-	public static int calculateServerSkyDarken(ClientLevel level) {
+	public static int calculateServerSkyDarken(Level level) {
 		double rainEffect = 1.0 - (double) (level.getRainLevel(1.0F) * 5.0F) / 16.0;
 		double thunderEffect = 1.0 - (double) (level.getThunderLevel(1.0F) * 5.0F) / 16.0;
 		double dayCycleEffect = 0.5 + 2.0 * Mth.clamp(Mth.cos(level.getTimeOfDay(1.0F) * (float) (Math.PI * 2)), -0.25, 0.25);
@@ -89,7 +89,7 @@ public class TrollsteinnBlock extends Block {
 			Level level = ctx.getLevel();
 			BlockPos pos = ctx.getClickedPos();
 			int light = level.getMaxLocalRawBrightness(pos.relative(e.getKey()),
-					level.isClientSide() ? calculateServerSkyDarken((ClientLevel) level) : level.getSkyDarken());
+				level.isClientSide() ? calculateServerSkyDarken(level) : level.getSkyDarken());
 			ret = ret.setValue(e.getValue(), light > LIGHT_THRESHOLD);
 		}
 		return ret;

--- a/src/main/java/twilightforest/block/TrollsteinnBlock.java
+++ b/src/main/java/twilightforest/block/TrollsteinnBlock.java
@@ -88,7 +88,8 @@ public class TrollsteinnBlock extends Block {
 		for (Map.Entry<Direction, BooleanProperty> e : PROPERTY_MAP.entrySet()) {
 			Level level = ctx.getLevel();
 			BlockPos pos = ctx.getClickedPos();
-			int light = level.getMaxLocalRawBrightness(pos.relative(e.getKey()), level instanceof ClientLevel clientLevel ? calculateServerSkyDarken(clientLevel) : level.getSkyDarken());
+			int light = level.getMaxLocalRawBrightness(pos.relative(e.getKey()),
+					level.isClientSide() ? calculateServerSkyDarken((ClientLevel) level) : level.getSkyDarken());
 			ret = ret.setValue(e.getValue(), light > LIGHT_THRESHOLD);
 		}
 		return ret;


### PR DESCRIPTION
# Overview

This is my first pull request for this project. Please let me know if there are any shortcomings.

Crashes occur when placing TrollsteinnBlocks while running twilightforest-1.21.1-4.7 on a dedicated server.
Crash log: https://gist.github.com/sbite0138/23ed73dcf5af0916cf84c201c2a85b28

# Root Cause

In TrollsteinnBlock#getStateForPlacement, light level is calculated as follows:

```java
int light = level.getMaxLocalRawBrightness(
     pos.relative(e.getKey()), 
     level instanceof ClientLevel clientLevel 
        ? calculateServerSkyDarken(clientLevel) 
        : level.getSkyDarken());
```

This ternary operator triggers class resolution for `net.minecraft.client.multiplayer.ClientLevel`, even on a dedicated server, and attempts to load client-specific classes. This causes a `ClassNotFoundException` error, resulting in the server crashing.

# Fix

Guard the client-specific path with level.isClientSide() and perform the cast to ClientLevel only within that branch.

```java
int light = level.getMaxLocalRawBrightness(
    pos.relative(e.getKey()),
    level.isClientSide()
       ? calculateServerSkyDarken((ClientLevel) level)
       : level.getSkyDarken()
);
```


