### PR TITLE
Adjust Misty Wolf's transparency level

### DIFF
--- a/src/main/java/twilightforest/client/model/entity/MistWolfModel.java
+++ b/src/main/java/twilightforest/client/model/entity/MistWolfModel.java
@@ -22,7 +22,7 @@ public class MistWolfModel extends HostileWolfModel<MistWolf> {
 		if (this.wolf != null) {
 			float brightness = this.wolf.level().getMaxLocalRawBrightness(this.wolf.blockPosition()) / 15.0F;
 			float misty = Math.min(1.0F, brightness * 3.0F + 0.25F);
-			float smoky = Math.min(1.0F, brightness * 2.0F + 0.6F);
+			float smoky = Math.min(1.0F, brightness * 2.0F + 0.3F);
 			super.renderToBuffer(stack, consumer, light, overlay, FastColor.ARGB32.colorFromFloat(smoky, misty, misty, misty));
 		} else {
 			super.renderToBuffer(stack, consumer, light, overlay, color);


### PR DESCRIPTION
Fix #2492 
Lower transparency level to 30% from 60%.

Before:
<img width="1920" height="1009" alt="517640678-288cce75-d4d1-4663-b94a-9aeececf6d21" src="https://github.com/user-attachments/assets/58f92230-bea0-4b6f-a923-69586d56cee1" />

After:
<img width="1920" height="1009" alt="517640665-9144d133-98eb-44da-b89e-8135a1b92baf" src="https://github.com/user-attachments/assets/e4f6eade-6d19-47f4-bc03-b137ed4e5126" />
