### PR TITLE
Fix Aurora Palace floor generation

### DIFF
--- a/src/main/java/twilightforest/world/components/structures/icetower/IceTowerWingComponent.java
+++ b/src/main/java/twilightforest/world/components/structures/icetower/IceTowerWingComponent.java
@@ -346,11 +346,11 @@ public class IceTowerWingComponent extends TowerWingComponent {
 				(floorCount - plan.size()) * 10,
 				(floorCount - plan.size() + 1) * 10
 			);
-			topBlockedParts.addAll(doorBlockedParts);
 			bottomBlockedParts = getPartsBlockedByDoors(
 				(floorCount - plan.size() - 1) * 10,  // 10 is always the height of the floor
 				(floorCount - plan.size()) * 10
 			);
+			bottomBlockedParts.addAll(doorBlockedParts);
 		}
 
 		return plan;


### PR DESCRIPTION
Fix #2463
Fixed Aurora Palace generation by moving doorBlockedParts from topBlockedParts to bottomBlockedParts. This allows new floors to generate properly. Tested in several worlds but further testing is recommended