### PR TITLE
Fix crash when StructureStart has no pieces in AvoidLandmarkModifier

### DIFF
--- a/src/main/java/twilightforest/world/components/placements/AvoidLandmarkModifier.java
+++ b/src/main/java/twilightforest/world/components/placements/AvoidLandmarkModifier.java
@@ -102,7 +102,7 @@ public class AvoidLandmarkModifier extends PlacementModifier {
 
 			StructureStart startForStructure = startChunk.getStartForStructure(structure);
 
-			if (startForStructure == null)
+			if (startForStructure == null || !startForStructure.isValid())
 				continue;
 
 			BlockPos diff = blockPos.subtract(startForStructure.getBoundingBox().getCenter());


### PR DESCRIPTION
Added `isValid()` check before calling `getBoundingBox()` to prevent crash when a StructureStart exists but has no pieces.

Fixes IllegalStateException: "Unable to calculate boundingbox without pieces"

This issue can be triggered unpredictably in modpacks due to other mods' behaviors affecting world generation, and is difficult to trace back to its source. Adding this defensive check ensures stability in complex modded environments.