### PR TITLE
Check if candle exists in CANDLE_MAP before converting to prevent crashes

### DIFF
--- a/src/main/java/twilightforest/entity/boss/Lich.java
+++ b/src/main/java/twilightforest/entity/boss/Lich.java
@@ -731,7 +731,7 @@ public class Lich extends BaseTFBoss {
 		for (BlockPos pos : BlockPos.betweenClosed(this.homeOrElseCurrent().offset(-range, -3, -range), this.homeOrElseCurrent().offset(range, yRange, range))) {
 			if (this.random.nextInt(Math.max(40 - tick, 2)) == 1 || done) {
 				BlockState state = this.level().getBlockState(pos);
-				if (state.getBlock() instanceof AbstractCandleBlock candleBlock && state.getValue(CandleBlock.LIT)) {
+				if (state.getBlock() instanceof AbstractCandleBlock candleBlock && OminousCandleBlock.CANDLE_MAP.containsKey(candleBlock) && state.getValue(CandleBlock.LIT)) {
 					this.level().setBlockAndUpdate(pos, OminousCandleBlock.CANDLE_MAP.get(candleBlock).get().defaultBlockState().setValue(OminousCandleBlock.CANDLES, state.getValue(CandleBlock.CANDLES)));
 					this.level().playSound(null, pos, TFSounds.OMINOUS_FIRE.get(), SoundSource.BLOCKS, 0.5F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 0.75F);
 				} else if (state.getBlock() instanceof LightableBlock && state.getValue(LightableBlock.LIGHTING) == LightableBlock.Lighting.NORMAL) {

--- a/src/main/java/twilightforest/item/ExanimateEssenceItem.java
+++ b/src/main/java/twilightforest/item/ExanimateEssenceItem.java
@@ -25,7 +25,7 @@ public class ExanimateEssenceItem extends Item {
 		BlockPos blockpos = context.getClickedPos();
 		boolean flag = false;
 		BlockState state = level.getBlockState(blockpos);
-		if (state.getBlock() instanceof CandleBlock candleBlock && state.getValue(CandleBlock.LIT)) {
+		if (state.getBlock() instanceof CandleBlock candleBlock && OminousCandleBlock.CANDLE_MAP.containsKey(candleBlock) && state.getValue(CandleBlock.LIT)) {
 			this.playSound(level, blockpos);
 			level.setBlockAndUpdate(blockpos, OminousCandleBlock.CANDLE_MAP.get(candleBlock).get().defaultBlockState().setValue(OminousCandleBlock.CANDLES, state.getValue(CandleBlock.CANDLES)));
 			level.gameEvent(context.getPlayer(), GameEvent.BLOCK_PLACE, blockpos);


### PR DESCRIPTION
If a mod adds their own candles that use CandleBlock or AbstractCandleBlock, the game would crash if they weren't in CANDLE_MAP, so this fixes that in such a way that other mods could add their own Ominous Candle variants. I'm sending this PR because it's such a simple fix, as well as to prevent it from being fixed in a way that breaks the mod I currently am working on to add support for Dyenamics candles. Also because cakes with candles use AbstractCandleBlock I'd think those would crash too without the check.