### PR TITLE
Port network to 26.1x

### DIFF
--- a/src/main/java/twilightforest/network/CreateMovingCicadaSoundPacket.java
+++ b/src/main/java/twilightforest/network/CreateMovingCicadaSoundPacket.java
@@ -5,7 +5,6 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.neoforge.network.handling.IPayloadContext;

--- a/src/main/java/twilightforest/network/CycleMapSlotPacket.java
+++ b/src/main/java/twilightforest/network/CycleMapSlotPacket.java
@@ -38,7 +38,7 @@ public record CycleMapSlotPacket() implements CustomPacketPayload {
 				ItemDisplayContents updatedContents = mutable.toImmutable();
 				headStack.set(TFDataComponents.ITEM_DISPLAY, updatedContents);
 				serverPlayer.getInventory().setChanged();
-				player.playNotifySound(newIndex == -1 ? TFSounds.CYCLE_MAPS_EMPTY.get() : TFSounds.CYCLE_MAPS.get(), player.getSoundSource(), 1F, 1F);
+				player.playSound(newIndex == -1 ? TFSounds.CYCLE_MAPS_EMPTY.get() : TFSounds.CYCLE_MAPS.get(), 1F, 1F);
 			}
 		});
 	}

--- a/src/main/java/twilightforest/network/EnforceProgressionStatusPacket.java
+++ b/src/main/java/twilightforest/network/EnforceProgressionStatusPacket.java
@@ -29,7 +29,7 @@ public record EnforceProgressionStatusPacket(boolean enforce) implements CustomP
 
 	public static void handle(EnforceProgressionStatusPacket message, IPayloadContext ctx) {
 		ctx.enqueueWork(() -> {
-			// I am not entirely sure that this approach is reliable or safe, it seems that the level no longer has access to game rules
+			// FIXME level no longer has access to game rules
 
 			MinecraftServer server = ctx.player().level().getServer();
 

--- a/src/main/java/twilightforest/network/EnforceProgressionStatusPacket.java
+++ b/src/main/java/twilightforest/network/EnforceProgressionStatusPacket.java
@@ -1,10 +1,10 @@
 package twilightforest.network;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.server.MinecraftServer;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import twilightforest.TwilightForestMod;
 import twilightforest.init.TFGameRules;
@@ -28,8 +28,14 @@ public record EnforceProgressionStatusPacket(boolean enforce) implements CustomP
 	}
 
 	public static void handle(EnforceProgressionStatusPacket message, IPayloadContext ctx) {
-		ctx.enqueueWork(() ->
-			Minecraft.getInstance().level.getGameRules().getRule(TFGameRules.ENFORCED_PROGRESSION_RULE.get()).set(message.enforce(), null)
-		);
+		ctx.enqueueWork(() -> {
+			// I am not entirely sure that this approach is reliable or safe, it seems that the level no longer has access to game rules
+
+			MinecraftServer server = ctx.player().level().getServer();
+
+			if(server != null) {
+				server.getGameRules().set(TFGameRules.ENFORCED_PROGRESSION_RULE.get(), message.enforce(), null);
+			}
+		});
 	}
 }

--- a/src/main/java/twilightforest/network/MagicMapPacket.java
+++ b/src/main/java/twilightforest/network/MagicMapPacket.java
@@ -30,32 +30,36 @@ public record MagicMapPacket(ClientboundMapItemDataPacket inner, List<String> co
 		return TYPE;
 	}
 
+	@SuppressWarnings("Convert2Lambda")
 	public static void handle(MagicMapPacket message, IPayloadContext ctx) {
 		//ensure this is only done on clients as this uses client only code
 		if (ctx.flow().isClientbound()) {
-			ctx.enqueueWork(() -> {
-				Level level = ctx.player().level();
+			ctx.enqueueWork(new Runnable() {
+				@Override
+				public void run() {
+					Level level = ctx.player().level();
 
-				String s = MagicMapItem.getMapName(message.inner.mapId().id());
-				TFMagicMapData mapdata = TFMagicMapData.getMagicMapData(level, s);
-				if (mapdata == null) {
-					mapdata = new TFMagicMapData(0, 0, message.inner.scale(), false, false, message.inner.locked(), level.dimension());
-					TFMagicMapData.registerMagicMapData(level, mapdata, s);
-				}
+					String s = MagicMapItem.getMapName(message.inner.mapId().id());
+					TFMagicMapData mapdata = TFMagicMapData.getMagicMapData(level, s);
+					if (mapdata == null) {
+						mapdata = new TFMagicMapData(0, 0, message.inner.scale(), false, false, message.inner.locked(), level.dimension());
+						TFMagicMapData.registerMagicMapData(level, mapdata, s);
+					}
 
-				message.inner.applyToMap(mapdata);
-				//TF: sync conquered structures for map
-				mapdata.conqueredStructures.clear();
-				mapdata.conqueredStructures.addAll(message.conqueredStructures());
+					message.inner.applyToMap(mapdata);
+					//TF: sync conquered structures for map
+					mapdata.conqueredStructures.clear();
+					mapdata.conqueredStructures.addAll(message.conqueredStructures());
 
-				// This may or may not be equivalent to updating the renderer directly, will need testing to verify
+					// This may or may not be equivalent to updating the renderer directly, will need testing to verify
 
-				MapItemSavedData saved = level.getMapData(message.inner.mapId());
+					MapItemSavedData saved = level.getMapData(message.inner.mapId());
 
-				if (saved != null) {
-					saved.addClientSideDecorations(
-						StreamSupport.stream(mapdata.getDecorations().spliterator(), false).toList()
-					);
+					if (saved != null) {
+						saved.addClientSideDecorations(
+							StreamSupport.stream(mapdata.getDecorations().spliterator(), false).toList()
+						);
+					}
 				}
 			});
 		}

--- a/src/main/java/twilightforest/network/MagicMapPacket.java
+++ b/src/main/java/twilightforest/network/MagicMapPacket.java
@@ -51,8 +51,6 @@ public record MagicMapPacket(ClientboundMapItemDataPacket inner, List<String> co
 					mapdata.conqueredStructures.clear();
 					mapdata.conqueredStructures.addAll(message.conqueredStructures());
 
-					// This may or may not be equivalent to updating the renderer directly, will need testing to verify
-
 					MapItemSavedData saved = level.getMapData(message.inner.mapId());
 
 					if (saved != null) {

--- a/src/main/java/twilightforest/network/MagicMapPacket.java
+++ b/src/main/java/twilightforest/network/MagicMapPacket.java
@@ -12,7 +12,6 @@ import twilightforest.TwilightForestMod;
 import twilightforest.item.MagicMapItem;
 import twilightforest.item.mapdata.TFMagicMapData;
 
-
 import java.util.List;
 import java.util.stream.StreamSupport;
 

--- a/src/main/java/twilightforest/network/MagicMapPacket.java
+++ b/src/main/java/twilightforest/network/MagicMapPacket.java
@@ -1,19 +1,20 @@
 package twilightforest.network;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.MapRenderer;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.network.protocol.game.ClientboundMapItemDataPacket;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import twilightforest.TwilightForestMod;
 import twilightforest.item.MagicMapItem;
 import twilightforest.item.mapdata.TFMagicMapData;
 
+
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 // Rewraps vanilla ClientboundMapItemDataPacket to sync conquered status of structures
 public record MagicMapPacket(ClientboundMapItemDataPacket inner, List<String> conqueredStructures) implements CustomPacketPayload {
@@ -29,29 +30,32 @@ public record MagicMapPacket(ClientboundMapItemDataPacket inner, List<String> co
 		return TYPE;
 	}
 
-	@SuppressWarnings("Convert2Lambda")
 	public static void handle(MagicMapPacket message, IPayloadContext ctx) {
 		//ensure this is only done on clients as this uses client only code
 		if (ctx.flow().isClientbound()) {
-			ctx.enqueueWork(new Runnable() {
-				@Override
-				public void run() {
-					Level level = ctx.player().level();
-					// [VanillaCopy] ClientPacketListener#handleMapItemData with our own mapdatas
-					MapRenderer mapitemrenderer = Minecraft.getInstance().gameRenderer.getMapRenderer();
-					String s = MagicMapItem.getMapName(message.inner.mapId().id());
-					TFMagicMapData mapdata = TFMagicMapData.getMagicMapData(level, s);
-					if (mapdata == null) {
-						mapdata = new TFMagicMapData(0, 0, message.inner.scale(), false, false, message.inner.locked(), level.dimension());
-						TFMagicMapData.registerMagicMapData(level, mapdata, s);
-					}
+			ctx.enqueueWork(() -> {
+				Level level = ctx.player().level();
 
-					message.inner.applyToMap(mapdata);
-					//TF: sync conquered structures for map
-					mapdata.conqueredStructures.clear();
-					mapdata.conqueredStructures.addAll(message.conqueredStructures());
+				String s = MagicMapItem.getMapName(message.inner.mapId().id());
+				TFMagicMapData mapdata = TFMagicMapData.getMagicMapData(level, s);
+				if (mapdata == null) {
+					mapdata = new TFMagicMapData(0, 0, message.inner.scale(), false, false, message.inner.locked(), level.dimension());
+					TFMagicMapData.registerMagicMapData(level, mapdata, s);
+				}
 
-					mapitemrenderer.update(message.inner.mapId(), mapdata);
+				message.inner.applyToMap(mapdata);
+				//TF: sync conquered structures for map
+				mapdata.conqueredStructures.clear();
+				mapdata.conqueredStructures.addAll(message.conqueredStructures());
+
+				// This may or may not be equivalent to updating the renderer directly, will need testing to verify
+
+				MapItemSavedData saved = level.getMapData(message.inner.mapId());
+
+				if (saved != null) {
+					saved.addClientSideDecorations(
+						StreamSupport.stream(mapdata.getDecorations().spliterator(), false).toList()
+					);
 				}
 			});
 		}

--- a/src/main/java/twilightforest/network/MazeMapPacket.java
+++ b/src/main/java/twilightforest/network/MazeMapPacket.java
@@ -1,17 +1,18 @@
 package twilightforest.network;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.MapRenderer;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.network.protocol.game.ClientboundMapItemDataPacket;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import twilightforest.TwilightForestMod;
 import twilightforest.item.MazeMapItem;
 import twilightforest.item.mapdata.TFMazeMapData;
+
+import java.util.stream.StreamSupport;
 
 // Rewraps vanilla ClientboundMapItemDataPacket to properly add our own data
 public record MazeMapPacket(ClientboundMapItemDataPacket inner, boolean ore, int yCenter) implements CustomPacketPayload {
@@ -30,27 +31,32 @@ public record MazeMapPacket(ClientboundMapItemDataPacket inner, boolean ore, int
 		return TYPE;
 	}
 
-	@SuppressWarnings("Convert2Lambda")
 	public static void handle(MazeMapPacket message, IPayloadContext ctx) {
 		//ensure this is only done on clients as this uses client only code
 		if (ctx.flow().isClientbound()) {
-			ctx.enqueueWork(new Runnable() {
-				@Override
-				public void run() {
-					Level level = ctx.player().level();
-					// [VanillaCopy] ClientPlayNetHandler#handleMaps with our own mapdatas
-					MapRenderer mapitemrenderer = Minecraft.getInstance().gameRenderer.getMapRenderer();
-					String s = MazeMapItem.getMapName(message.inner().mapId().id());
-					TFMazeMapData mapdata = TFMazeMapData.getMazeMapData(level, s);
-					if (mapdata == null) {
-						mapdata = new TFMazeMapData(0, 0, message.inner().scale(), false, false, message.inner().locked(), level.dimension());
-						TFMazeMapData.registerMazeMapData(level, mapdata, s);
-					}
+			ctx.enqueueWork(() -> {
+				Level level = ctx.player().level();
 
-					mapdata.ore = message.ore();
-					mapdata.yCenter = message.yCenter();
-					message.inner().applyToMap(mapdata);
-					mapitemrenderer.update(message.inner().mapId(), mapdata);
+				String s = MazeMapItem.getMapName(message.inner().mapId().id());
+				TFMazeMapData mapdata = TFMazeMapData.getMazeMapData(level, s);
+				if (mapdata == null) {
+					mapdata = new TFMazeMapData(0, 0, message.inner().scale(), false, false, message.inner().locked(), level.dimension());
+					TFMazeMapData.registerMazeMapData(level, mapdata, s);
+				}
+
+				mapdata.ore = message.ore();
+				mapdata.yCenter = message.yCenter();
+				message.inner().applyToMap(mapdata);
+
+				// This may or may not be equivalent to updating the renderer directly, will need testing to verify
+
+
+				MapItemSavedData saved = level.getMapData(message.inner().mapId());
+
+				if (saved != null) {
+					saved.addClientSideDecorations(
+						StreamSupport.stream(mapdata.getDecorations().spliterator(), false).toList()
+					);
 				}
 			});
 		}

--- a/src/main/java/twilightforest/network/MazeMapPacket.java
+++ b/src/main/java/twilightforest/network/MazeMapPacket.java
@@ -58,8 +58,6 @@ public record MazeMapPacket(ClientboundMapItemDataPacket inner, boolean ore, int
 					mapdata.yCenter = message.yCenter();
 					message.inner().applyToMap(mapdata);
 
-					// This may or may not be equivalent to updating the renderer directly, will need testing to verify
-
 					MapItemSavedData saved = level.getMapData(message.inner().mapId());
 
 					if (saved != null) {

--- a/src/main/java/twilightforest/network/MazeMapPacket.java
+++ b/src/main/java/twilightforest/network/MazeMapPacket.java
@@ -31,32 +31,42 @@ public record MazeMapPacket(ClientboundMapItemDataPacket inner, boolean ore, int
 		return TYPE;
 	}
 
+	@SuppressWarnings("Convert2Lambda")
 	public static void handle(MazeMapPacket message, IPayloadContext ctx) {
 		//ensure this is only done on clients as this uses client only code
 		if (ctx.flow().isClientbound()) {
-			ctx.enqueueWork(() -> {
-				Level level = ctx.player().level();
+			ctx.enqueueWork(new Runnable() {
+				@Override
+				public void run() {
+					Level level = ctx.player().level();
 
-				String s = MazeMapItem.getMapName(message.inner().mapId().id());
-				TFMazeMapData mapdata = TFMazeMapData.getMazeMapData(level, s);
-				if (mapdata == null) {
-					mapdata = new TFMazeMapData(0, 0, message.inner().scale(), false, false, message.inner().locked(), level.dimension());
-					TFMazeMapData.registerMazeMapData(level, mapdata, s);
-				}
+					String s = MazeMapItem.getMapName(message.inner().mapId().id());
+					TFMazeMapData mapdata = TFMazeMapData.getMazeMapData(level, s);
+					if (mapdata == null) {
+						mapdata = new TFMazeMapData(
+							0, 0,
+							message.inner().scale(),
+							false,
+							false,
+							message.inner().locked(),
+							level.dimension()
+						);
+						TFMazeMapData.registerMazeMapData(level, mapdata, s);
+					}
 
-				mapdata.ore = message.ore();
-				mapdata.yCenter = message.yCenter();
-				message.inner().applyToMap(mapdata);
+					mapdata.ore = message.ore();
+					mapdata.yCenter = message.yCenter();
+					message.inner().applyToMap(mapdata);
 
-				// This may or may not be equivalent to updating the renderer directly, will need testing to verify
+					// This may or may not be equivalent to updating the renderer directly, will need testing to verify
 
+					MapItemSavedData saved = level.getMapData(message.inner().mapId());
 
-				MapItemSavedData saved = level.getMapData(message.inner().mapId());
-
-				if (saved != null) {
-					saved.addClientSideDecorations(
-						StreamSupport.stream(mapdata.getDecorations().spliterator(), false).toList()
-					);
+					if (saved != null) {
+						saved.addClientSideDecorations(
+							StreamSupport.stream(mapdata.getDecorations().spliterator(), false).toList()
+						);
+					}
 				}
 			});
 		}

--- a/src/main/java/twilightforest/network/MissingAdvancementToastPacket.java
+++ b/src/main/java/twilightforest/network/MissingAdvancementToastPacket.java
@@ -1,16 +1,12 @@
 package twilightforest.network;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemStackTemplate;
-import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import twilightforest.TwilightForestMod;
 import twilightforest.client.MissingAdvancementToast;

--- a/src/main/java/twilightforest/network/ParticlePacket.java
+++ b/src/main/java/twilightforest/network/ParticlePacket.java
@@ -30,7 +30,7 @@ public class ParticlePacket implements CustomPacketPayload {
 			ParticleType<?> type = BuiltInRegistries.PARTICLE_TYPE.byId(buf.readInt());
 			if (type == null)
 				break; // Fail silently and end execution entirely. Due to Type serialization we now have completely unknown data in the pipeline without any way to safely read it all
-			this.queuedParticles.add(new QueuedParticle(ParticleTypes.STREAM_CODEC.decode(buf), buf.readBoolean(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble()));
+			this.queuedParticles.add(new QueuedParticle(ParticleTypes.STREAM_CODEC.decode(buf), buf.readBoolean(), buf.readBoolean(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble()));
 		}
 	}
 
@@ -55,22 +55,24 @@ public class ParticlePacket implements CustomPacketPayload {
 		return TYPE;
 	}
 
-	public void queueParticle(ParticleOptions particleOptions, boolean b, double x, double y, double z, double x2, double y2, double z2) {
-		this.queuedParticles.add(new QueuedParticle(particleOptions, b, x, y, z, x2, y2, z2));
+	public void queueParticle(ParticleOptions particleOptions, boolean b, boolean b2, double x, double y, double z, double x2, double y2, double z2) {
+		this.queuedParticles.add(new QueuedParticle(particleOptions, b, b2, x, y, z, x2, y2, z2));
 	}
 
-	public void queueParticle(ParticleOptions particleOptions, boolean b, Vec3 xyz, Vec3 xyz2) {
-		this.queuedParticles.add(new QueuedParticle(particleOptions, b, xyz.x, xyz.y, xyz.z, xyz2.x, xyz2.y, xyz2.z));
+	public void queueParticle(ParticleOptions particleOptions, boolean b, boolean b2, Vec3 xyz, Vec3 xyz2) {
+		this.queuedParticles.add(new QueuedParticle(particleOptions, b, b2, xyz.x, xyz.y, xyz.z, xyz2.x, xyz2.y, xyz2.z));
 	}
 
-	private record QueuedParticle(ParticleOptions particleOptions, boolean b, double x, double y, double z, double x2,
+
+	// Important to note that b2 is equivalent to b on the old call sites, b now represents the new parameter 'overrideLimiter'
+	private record QueuedParticle(ParticleOptions particleOptions, boolean b, boolean b2, double x, double y, double z, double x2,
 								  double y2, double z2) {
 	}
 
 	public static void handle(ParticlePacket message, IPayloadContext ctx) {
 		ctx.enqueueWork(() -> {
 			for (QueuedParticle queuedParticle : message.queuedParticles) {
-				ctx.player().level().addParticle(queuedParticle.particleOptions, queuedParticle.b, queuedParticle.x, queuedParticle.y, queuedParticle.z, queuedParticle.x2, queuedParticle.y2, queuedParticle.z2);
+				ctx.player().level().addParticle(queuedParticle.particleOptions, queuedParticle.b, queuedParticle.b2, queuedParticle.x, queuedParticle.y, queuedParticle.z, queuedParticle.x2, queuedParticle.y2, queuedParticle.z2);
 			}
 		});
 	}

--- a/src/main/java/twilightforest/network/ParticlePacket.java
+++ b/src/main/java/twilightforest/network/ParticlePacket.java
@@ -41,6 +41,7 @@ public class ParticlePacket implements CustomPacketPayload {
 			buf.writeInt(d);
 			ParticleTypes.STREAM_CODEC.encode(buf, queuedParticle.particleOptions);
 			buf.writeBoolean(queuedParticle.b);
+			buf.writeBoolean(queuedParticle.b2);
 			buf.writeDouble(queuedParticle.x);
 			buf.writeDouble(queuedParticle.y);
 			buf.writeDouble(queuedParticle.z);
@@ -63,8 +64,6 @@ public class ParticlePacket implements CustomPacketPayload {
 		this.queuedParticles.add(new QueuedParticle(particleOptions, b, b2, xyz.x, xyz.y, xyz.z, xyz2.x, xyz2.y, xyz2.z));
 	}
 
-
-	// Important to note that b2 is equivalent to b on the old call sites, b now represents the new parameter 'overrideLimiter'
 	private record QueuedParticle(ParticleOptions particleOptions, boolean b, boolean b2, double x, double y, double z, double x2,
 								  double y2, double z2) {
 	}

--- a/src/main/java/twilightforest/network/PerformSidestepPacket.java
+++ b/src/main/java/twilightforest/network/PerformSidestepPacket.java
@@ -5,7 +5,6 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import twilightforest.TwilightForestMod;
-import twilightforest.item.travellers_gear.TravellersArmorItem;
 import twilightforest.item.travellers_gear.TravellersGearLogic;
 
 public record PerformSidestepPacket(boolean isLeftStepSide) implements CustomPacketPayload {

--- a/src/main/java/twilightforest/network/SpawnCharmPacket.java
+++ b/src/main/java/twilightforest/network/SpawnCharmPacket.java
@@ -2,6 +2,7 @@ package twilightforest.network;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.Holder;
 import net.minecraft.core.particles.ItemParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -51,13 +52,13 @@ public record SpawnCharmPacket(ItemStack charm, ResourceKey<SoundEvent> event) i
 					if (TFConfig.spawnCharmAnimationAsTotem) {
 						Minecraft.getInstance().gameRenderer.displayItemActivation(packet.charm());
 						//prefer the camera pos over the player as the player position isnt quite synced to the client yet
-						Minecraft.getInstance().particleEngine.createTrackingEmitter(camera != null ? camera : player, new ItemParticleOption(ParticleTypes.ITEM, packet.charm()), 20);
+						Minecraft.getInstance().particleEngine.createTrackingEmitter(camera != null ? camera : player, new ItemParticleOption(ParticleTypes.ITEM, packet.charm().getItem()), 20);
 					} else {
 						CharmEffect effect = new CharmEffect(TFEntities.CHARM_EFFECT.get(), player.level(), player, packet.charm());
 						effect.offset = (float) Math.PI;
 						level.addEntity(effect);
 					}
-					SoundEvent event = BuiltInRegistries.SOUND_EVENT.get(packet.event());
+					SoundEvent event = BuiltInRegistries.SOUND_EVENT.get(packet.event()).map(Holder.Reference::value).orElse(null);
 					if (camera != null && event != null) {
 						level.playLocalSound(camera.getX(), camera.getY(), camera.getZ(), event, player.getSoundSource(), 1.5F, 1.0F, false);
 					}

--- a/src/main/java/twilightforest/network/SpawnFallenLeafFromPacket.java
+++ b/src/main/java/twilightforest/network/SpawnFallenLeafFromPacket.java
@@ -1,6 +1,5 @@
 package twilightforest.network;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ColorParticleOption;
 import net.minecraft.network.FriendlyByteBuf;
@@ -9,11 +8,9 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import twilightforest.TwilightForestMod;
-import twilightforest.client.particle.data.LeafParticleData;
 import twilightforest.init.TFParticleType;
 
 import java.util.Random;
@@ -43,7 +40,8 @@ public record SpawnFallenLeafFromPacket(BlockPos pos, Vec3 motion) implements Cu
 		ctx.enqueueWork(() -> {
 			Level level = ctx.player().level();
 			Random rand = new Random();
-			int color = Minecraft.getInstance().getBlockColors().getColor(Blocks.OAK_LEAVES.defaultBlockState(), level, message.pos(), 0);
+			// I think this is the correct replacement for getColor(...), but there may be a better option I missed
+			int color = level.getClientLeafTintColor(message.pos());
 			int r = Mth.clamp(((color >> 16) & 0xFF) + rand.nextInt(0x22) - 0x11, 0x00, 0xFF);
 			int g = Mth.clamp(((color >> 8) & 0xFF) + rand.nextInt(0x22) - 0x11, 0x00, 0xFF);
 			int b = Mth.clamp((color & 0xFF) + rand.nextInt(0x22) - 0x11, 0x00, 0xFF);

--- a/src/main/java/twilightforest/network/StructureProtectionPacket.java
+++ b/src/main/java/twilightforest/network/StructureProtectionPacket.java
@@ -6,9 +6,13 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.neoforged.neoforge.client.CustomEnvironmentEffectsRendererManager;
+import net.neoforged.neoforge.client.CustomWeatherEffectRenderer;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import twilightforest.TwilightForestMod;
+import twilightforest.client.TwilightForestRenderInfo;
 import twilightforest.client.renderer.TFWeatherRenderer;
+import twilightforest.init.TFDimension;
 import twilightforest.util.Codecs;
 
 import java.util.List;
@@ -31,9 +35,12 @@ public record StructureProtectionPacket(Optional<List<Pair<BoundingBox, Boolean>
 	}
 
 	public static void handle(StructureProtectionPacket message, IPayloadContext ctx) {
-		// Probably more work to be done here, the entire dimension effect system seems to have changed
-		ctx.enqueueWork(() ->
-			TFWeatherRenderer.setProtectedBoxes(message.boxes().orElse(null))
-		);
+		CustomWeatherEffectRenderer info = CustomEnvironmentEffectsRendererManager.getCustomWeatherEffectRenderer(TFDimension.DIMENSION_RENDERER);
+
+		if (info instanceof TwilightForestRenderInfo) {
+			ctx.enqueueWork(() ->
+				TFWeatherRenderer.setProtectedBoxes(message.boxes().orElse(null))
+			);
+		}
 	}
 }

--- a/src/main/java/twilightforest/network/StructureProtectionPacket.java
+++ b/src/main/java/twilightforest/network/StructureProtectionPacket.java
@@ -1,18 +1,14 @@
 package twilightforest.network;
 
 import com.mojang.datafixers.util.Pair;
-import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
-import net.neoforged.neoforge.client.DimensionSpecialEffectsManager;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import twilightforest.TwilightForestMod;
-import twilightforest.client.TwilightForestRenderInfo;
 import twilightforest.client.renderer.TFWeatherRenderer;
-import twilightforest.init.TFDimension;
 import twilightforest.util.Codecs;
 
 import java.util.List;
@@ -35,13 +31,9 @@ public record StructureProtectionPacket(Optional<List<Pair<BoundingBox, Boolean>
 	}
 
 	public static void handle(StructureProtectionPacket message, IPayloadContext ctx) {
-		ctx.enqueueWork(() -> {
-			DimensionSpecialEffects info = DimensionSpecialEffectsManager.getForType(TFDimension.DIMENSION_RENDERER);
-
-			// Now you have a List<Pair<BoundingBox, Boolean>>
-			if (info instanceof TwilightForestRenderInfo) {
-				TFWeatherRenderer.setProtectedBoxes(message.boxes().orElse(null));
-			}
-		});
+		// Probably more work to be done here, the entire dimension effect system seems to have changed
+		ctx.enqueueWork(() ->
+			TFWeatherRenderer.setProtectedBoxes(message.boxes().orElse(null))
+		);
 	}
 }

--- a/src/main/java/twilightforest/network/SyncUncraftingTableConfigPacket.java
+++ b/src/main/java/twilightforest/network/SyncUncraftingTableConfigPacket.java
@@ -4,10 +4,7 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.resources.Identifier;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
-import twilightforest.config.ConfigSetup;
-import twilightforest.config.TFCommonConfig;
 import twilightforest.config.TFConfig;
 import twilightforest.TwilightForestMod;
 


### PR DESCRIPTION
I updated the files under the *network* package to remove all of the compiler errors. I've left comments in areas where I am uncertain about actual behavior or where more work will need to be done in other parts of the mod. I would be happy to work on any edits here if requested or on updating other parts of the mod if it would be helpful. I have marked this PR as a draft due to the fact that the accuracy of a few of these changes somewhat depends on the rest of the mod being updated and tested in-game.

Here is a summary of the changes:
- Removed unused imports across the package
- Switched to *playSound* instead of *playSoundSource*
- Added a possible implementation of the game rule enforcement handler as the previous method is no longer applicable
- Added a possible implementation of the map data handler as the previous method is no longer applicable
- Refactored *ParticlePacket* and *QueuedParticle* to reflect an addition parameter in *addParticle*
- Added a *getItem* call in *SpawnCharmPacket* and unwrapped the optional sound event
- Added a possible implementation of getting the block color in *SpawnFallenLeafFromPacket*
- Removed inapplicable logic from *StructureProtectionPacket*, dimension effects in general will need a refactor