### PR TITLE
fix #2587

### DIFF
--- a/src/main/java/twilightforest/block/VanishingBlock.java
+++ b/src/main/java/twilightforest/block/VanishingBlock.java
@@ -54,6 +54,7 @@ public class VanishingBlock extends Block {
 		Deque<BlockPos> queue = new ArrayDeque<>();
 		Set<BlockPos> checked = new HashSet<>();
 		queue.offer(start);
+		checked.add(start);
 
 		for (int iter = 0; !queue.isEmpty() && iter < limit; iter++) {
 			BlockPos cur = queue.pop();
@@ -62,12 +63,11 @@ public class VanishingBlock extends Block {
 				return true;
 			}
 
-			checked.add(cur);
-
 			if (state.getBlock() instanceof VanishingBlock) {
 				for (Direction facing : Direction.values()) {
 					BlockPos neighbor = cur.relative(facing);
 					if (!checked.contains(neighbor)) {
+						checked.add(neighbor);
 						queue.offer(neighbor);
 					}
 				}
@@ -99,11 +99,7 @@ public class VanishingBlock extends Block {
 	@Override
 	protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hit) {
 		if (!this.isVanished(state) && !state.getValue(ACTIVE)) {
-			if (areBlocksLocked(level, pos)) {
-				level.playSound(null, pos, TFSounds.LOCKED_VANISHING_BLOCK.get(), SoundSource.BLOCKS, 1.0F, 0.3F);
-			} else {
-				this.activate(level, pos);
-			}
+			this.activate(level, pos);
 			return InteractionResult.sidedSuccess(level.isClientSide());
 		}
 
@@ -188,6 +184,10 @@ public class VanishingBlock extends Block {
 	}
 
 	private void activate(Level level, BlockPos pos) {
+		if (areBlocksLocked(level, pos)) {
+			level.playSound(null, pos, TFSounds.LOCKED_VANISHING_BLOCK.get(), SoundSource.BLOCKS, 1.0F, 0.3F);
+			return;
+		}
 		BlockState state = level.getBlockState(pos);
 		if (state.getBlock() instanceof VanishingBlock && !isVanished(state) && !state.getValue(ACTIVE)) {
 			level.setBlockAndUpdate(pos, state.setValue(ACTIVE, true));


### PR DESCRIPTION
Checking areBlocksLocked before activate can prevent the operation like in video #2587. I did not change the redstone check because I think that's too noisy.