### PR TITLE
Fix items 1.21.x

### DIFF
--- a/src/main/java/twilightforest/item/BrittleFlaskItem.java
+++ b/src/main/java/twilightforest/item/BrittleFlaskItem.java
@@ -4,6 +4,8 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.stats.Stats;
 import net.minecraft.util.ARGB;
 import net.minecraft.world.InteractionHand;
@@ -112,9 +114,6 @@ public class BrittleFlaskItem extends Item {
 		if (flaskContents.potion() != PotionContents.EMPTY) {
 			if (entity instanceof Player player) {
 				if (level instanceof ServerLevel serverLevel) {
-					if (!player.isCreative() && !player.isSpectator() && player instanceof ServerPlayer serverPlayer) {
-						flaskContents.potion().potion().ifPresent(potion -> player.getData(TFDataAttachments.FLASK_DOSES).trackDrink(potion, serverPlayer));
-					}
 					for (MobEffectInstance mobeffectinstance : flaskContents.potion().getAllEffects()) {
 						if (mobeffectinstance.is(MobEffects.HARM) != entity.isInvertedHealAndHarm() && mobeffectinstance.getAmplifier() > 0) {
 							//custom harming death message for the advancement
@@ -125,6 +124,7 @@ public class BrittleFlaskItem extends Item {
 							player.addEffect(new MobEffectInstance(mobeffectinstance));
 						}
 					}
+
 					if (!player.isCreative() && !player.isSpectator() && player instanceof ServerPlayer serverPlayer) {
 						flaskContents.potion().potion().ifPresent(potion -> player.getData(TFDataAttachments.FLASK_DOSES).trackDrink(potion, serverPlayer));
 					}

--- a/src/main/java/twilightforest/item/BrittleFlaskItem.java
+++ b/src/main/java/twilightforest/item/BrittleFlaskItem.java
@@ -1,11 +1,8 @@
 package twilightforest.item;
 
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.sounds.SoundEvent;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.stats.Stats;
 import net.minecraft.util.ARGB;
 import net.minecraft.world.InteractionHand;

--- a/src/main/java/twilightforest/item/PeacockFanItem.java
+++ b/src/main/java/twilightforest/item/PeacockFanItem.java
@@ -101,7 +101,7 @@ public class PeacockFanItem extends Item {
 	@Nonnull
 	@Override
 	public ItemUseAnimation getUseAnimation(ItemStack stack) {
-		return ItemUseAnimation.BLOCK;
+		return ItemUseAnimation.NONE;
 	}
 
 	@Override


### PR DESCRIPTION
This PR fixes two issue related to items behavior in the 1.21.x port: the early triggering of the alchemist advancement and the broken legacy sword block animation on the peacock fan.

### Changes
- **Flask / Advancement**: Removed duplicate `trackDrink` method call after applying potion effects that was causing the counter to double-increment per single use.
- **Peacock Fan**: Removed the outdated `UseAnim.BLOCK` that was causing the item to freeze awkwardly in front of the player's face like a 1.8 blocking sword.

### Fixes
- Fixes #2433
- Fixes #2412
