### PR TITLE
Fix Upper Goblin Knight damage scaling and stabilize heavy spear attack

### DIFF
--- a/src/main/java/twilightforest/entity/ai/goal/HeavySpearAttackGoal.java
+++ b/src/main/java/twilightforest/entity/ai/goal/HeavySpearAttackGoal.java
@@ -10,6 +10,7 @@ import java.util.EnumSet;
 public class HeavySpearAttackGoal extends Goal {
 
 	private final UpperGoblinKnight entity;
+	private boolean hasAttackedInThisCycle = false;
 
 	public HeavySpearAttackGoal(UpperGoblinKnight upperKnight) {
 		this.entity = upperKnight;
@@ -17,9 +18,15 @@ public class HeavySpearAttackGoal extends Goal {
 	}
 
 	@Override
+	public void start() {
+		hasAttackedInThisCycle = false;
+	}
+
+	@Override
 	public void tick() {
-		if (this.entity.heavySpearTimer == 25) {
+		if (this.entity.heavySpearTimer <= 25 && !hasAttackedInThisCycle) {
 			this.entity.landHeavySpearAttack((ServerLevel) this.entity.level());
+			hasAttackedInThisCycle = true;
 		}
 	}
 

--- a/src/main/java/twilightforest/entity/monster/UpperGoblinKnight.java
+++ b/src/main/java/twilightforest/entity/monster/UpperGoblinKnight.java
@@ -44,7 +44,7 @@ public class UpperGoblinKnight extends Monster {
 	private static final EntityDataAccessor<Boolean> SHIELD_DISABLED = SynchedEntityData.defineId(UpperGoblinKnight.class, EntityDataSerializers.BOOLEAN);
 
 	private static final AttributeModifier ARMOR_MODIFIER = new AttributeModifier(TwilightForestMod.prefix("armor_boost"), 20, AttributeModifier.Operation.ADD_VALUE);
-	private static final AttributeModifier DAMAGE_MODIFIER = new AttributeModifier(TwilightForestMod.prefix("spear_attack_boost"), 12, AttributeModifier.Operation.ADD_MULTIPLIED_BASE);
+	private static final AttributeModifier DAMAGE_MODIFIER = new AttributeModifier(TwilightForestMod.prefix("spear_attack_boost"), 12, AttributeModifier.Operation.ADD_VALUE);
 	public static final int HEAVY_SPEAR_TIMER_START = 60;
 
 	private int shieldHits = 0;
@@ -223,8 +223,15 @@ public class UpperGoblinKnight extends Monster {
 		List<Entity> inBox = this.level().getEntities(this, spearBB, e -> e != this.getVehicle());
 
 		for (Entity entity : inBox) {
-			super.doHurtTarget(level, entity);
+			if (entity instanceof LivingEntity livingEntity) {
+				DamageSource source = level.damageSources().mobAttack(this);
+
+				float damageAmount = (float) this.getAttributeValue(Attributes.ATTACK_DAMAGE);
+
+				livingEntity.hurtServer(level, source, damageAmount);
+			}
 		}
+
 
 		if (!inBox.isEmpty()) {
 			this.playSound(SoundEvents.PLAYER_ATTACK_CRIT, getSoundVolume(), getVoicePitch());


### PR DESCRIPTION
- Changed AttributeModifier operation to ADD_VALUE to fix the 104 damage bug.
- Switched to livingEntity.hurtServer to properly calculate armor and protection enchantments.
- Replaced fragile "== 25" tick check in HeavySpearAttackGoal with a reliable boolean flag to prevent tick-skipping bugs during server lag.
Fixes #2609