### PR TITLE
Fix invalid type signature in Beardifier coremod

### DIFF
--- a/tf-asm/src/main/java/twilightforest/asm/transformers/beardifier/BeardifierClassTransformer.java
+++ b/tf-asm/src/main/java/twilightforest/asm/transformers/beardifier/BeardifierClassTransformer.java
@@ -23,7 +23,7 @@ public class BeardifierClassTransformer implements ITransformer<ClassNode> {
 			Opcodes.ACC_PUBLIC,
 			"twilightforest_customStructureDensities",
 			"Lit/unimi/dsi/fastutil/objects/ObjectListIterator;",
-			"Lit/unimi/dsi/fastutil/objects/ObjectListIterator<net.minecraft.world.level.levelgen.DensityFunction>;",
+			"Lit/unimi/dsi/fastutil/objects/ObjectListIterator<Lnet/minecraft/world/level/levelgen/DensityFunction;>;",
 			null
 		));
 		return node;


### PR DESCRIPTION
Howdy, while I was working on my mod Kilt for 1.21.1, I ended up encountering a crash in ASM itself (more specifically in [`SignatureReader#parseType`](https://gitlab.ow2.org/asm/asm/-/blob/master/asm/src/main/java/org/objectweb/asm/signature/SignatureReader.java#L249)) relating to the Beardifier coremod's field type signature while remapping it, largely because the original signature was invalid according to [the JVM specification itself](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-TypeArgument).

Main reason why this didn't cause problems previously is largely because most JVMs don't validate type signatures, although if they did it would definitely fail here.

This should also cleanly apply to the 26.1.x branch. The signature also appears to be [invalid in the 1.20.x branch too](https://github.com/TeamTwilight/twilightforest/blob/1.20.x/src/main/resources/META-INF/asm/structure_terraform.js#L27), so it should probably be fixed there too.