### PR TITLE
Port dispenser to 26.1.x

### DIFF
--- a/src/main/java/twilightforest/block/AbstractSkullCandleBlock.java
+++ b/src/main/java/twilightforest/block/AbstractSkullCandleBlock.java
@@ -128,7 +128,7 @@ public abstract class AbstractSkullCandleBlock extends BaseEntityBlock implement
 	protected InteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult result) {
 		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) {
 			if (stack.is(ItemTags.CANDLES)
-				&& stack.is(candleColorToCandle(CandleColors.colorFromInt(sc.candleInfo.color())).asItem())
+				&& stack.is(candleColorToCandle(CandleColors.colorFromInt(sc.getCandleInfo().color())).asItem())
 				&& !player.isShiftKeyDown()) {
 				int candles = state.getValue(CANDLES);
 				if (candles < 4) {
@@ -168,7 +168,7 @@ public abstract class AbstractSkullCandleBlock extends BaseEntityBlock implement
 			}
 			level.playSound(null, pos, SoundEvents.CANDLE_BREAK, SoundSource.BLOCKS, 1.0F, 1.0F);
 			level.getLightEngine().checkBlock(pos);
-			ItemStack candle = new ItemStack(candleColorToCandle(CandleColors.colorFromInt(sc.candleInfo.color())));
+			ItemStack candle = new ItemStack(candleColorToCandle(CandleColors.colorFromInt(sc.getCandleInfo().color())));
 			if (player.hasInfiniteMaterials()) {
 				if (!player.getInventory().contains(candle)) {
 					player.getInventory().add(candle);

--- a/src/main/java/twilightforest/block/entity/SkullCandleBlockEntity.java
+++ b/src/main/java/twilightforest/block/entity/SkullCandleBlockEntity.java
@@ -37,35 +37,30 @@ public class SkullCandleBlockEntity extends SkullBlockEntity {
 	protected void saveAdditional(ValueOutput output) {
 		super.saveAdditional(output);
 		output.store("info", SkullCandles.CODEC, this.candleInfo);
-		output.storeNullable("profile", ResolvableProfile.CODEC, this.owner);
 	}
 
 	@Override
 	protected void loadAdditional(ValueInput input) {
 		super.loadAdditional(input);
 		this.candleInfo = input.read("info", SkullCandles.CODEC).orElse(SkullCandles.DEFAULT);
-		this.owner = input.read("profile", ResolvableProfile.CODEC).orElse(null);
 	}
 
 	@Override
 	protected void applyImplicitComponents(DataComponentGetter components) {
 		super.applyImplicitComponents(components);
 		this.candleInfo = components.getOrDefault(TFDataComponents.SKULL_CANDLES, SkullCandles.DEFAULT);
-		this.owner = components.get(DataComponents.PROFILE);
 	}
 
 	@Override
 	protected void collectImplicitComponents(DataComponentMap.Builder components) {
 		super.collectImplicitComponents(components);
 		components.set(TFDataComponents.SKULL_CANDLES, this.candleInfo);
-		components.set(DataComponents.PROFILE, this.owner);
 	}
 
 	@Override
 	public void removeComponentsFromTag(ValueOutput output) {
 		super.removeComponentsFromTag(output);
 		output.discard("info");
-		output.discard("profile");
 	}
 
 	@Override

--- a/src/main/java/twilightforest/block/entity/SkullCandleBlockEntity.java
+++ b/src/main/java/twilightforest/block/entity/SkullCandleBlockEntity.java
@@ -3,18 +3,21 @@ package twilightforest.block.entity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponentGetter;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.component.ResolvableProfile;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.SkullBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
+import org.jspecify.annotations.Nullable;
 import twilightforest.components.item.SkullCandles;
 import twilightforest.init.TFBlockEntities;
 import twilightforest.init.TFDataComponents;
 
 public class SkullCandleBlockEntity extends SkullBlockEntity {
-
-	public SkullCandles candleInfo = SkullCandles.DEFAULT;
+	private SkullCandles candleInfo = SkullCandles.DEFAULT;
+	private @Nullable ResolvableProfile owner;
 
 	public SkullCandleBlockEntity(BlockPos pos, BlockState state) {
 		super(pos, state);
@@ -34,29 +37,43 @@ public class SkullCandleBlockEntity extends SkullBlockEntity {
 	protected void saveAdditional(ValueOutput output) {
 		super.saveAdditional(output);
 		output.store("info", SkullCandles.CODEC, this.candleInfo);
+		output.storeNullable("profile", ResolvableProfile.CODEC, this.owner);
 	}
 
 	@Override
 	protected void loadAdditional(ValueInput input) {
 		super.loadAdditional(input);
 		this.candleInfo = input.read("info", SkullCandles.CODEC).orElse(SkullCandles.DEFAULT);
+		this.owner = input.read("profile", ResolvableProfile.CODEC).orElse(null);
 	}
 
 	@Override
 	protected void applyImplicitComponents(DataComponentGetter components) {
 		super.applyImplicitComponents(components);
 		this.candleInfo = components.getOrDefault(TFDataComponents.SKULL_CANDLES, SkullCandles.DEFAULT);
+		this.owner = components.get(DataComponents.PROFILE);
 	}
 
 	@Override
 	protected void collectImplicitComponents(DataComponentMap.Builder components) {
 		super.collectImplicitComponents(components);
 		components.set(TFDataComponents.SKULL_CANDLES, this.candleInfo);
+		components.set(DataComponents.PROFILE, this.owner);
 	}
 
 	@Override
 	public void removeComponentsFromTag(ValueOutput output) {
 		super.removeComponentsFromTag(output);
 		output.discard("info");
+		output.discard("profile");
+	}
+
+	@Override
+	public @Nullable ResolvableProfile getOwnerProfile() {
+		return this.owner;
+	}
+
+	public SkullCandles getCandleInfo() {
+		return this.candleInfo;
 	}
 }

--- a/src/main/java/twilightforest/block/entity/SkullCandleBlockEntity.java
+++ b/src/main/java/twilightforest/block/entity/SkullCandleBlockEntity.java
@@ -3,6 +3,7 @@ package twilightforest.block.entity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponentGetter;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.component.ResolvableProfile;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -17,7 +18,6 @@ import twilightforest.init.TFDataComponents;
 
 public class SkullCandleBlockEntity extends SkullBlockEntity {
 	private SkullCandles candleInfo = SkullCandles.DEFAULT;
-	private @Nullable ResolvableProfile owner;
 
 	public SkullCandleBlockEntity(BlockPos pos, BlockState state) {
 		super(pos, state);
@@ -73,7 +73,21 @@ public class SkullCandleBlockEntity extends SkullBlockEntity {
 		return this.owner;
 	}
 
+	public void setOwnerProfile(ResolvableProfile newProfile) {
+		DataComponentPatch patch = DataComponentPatch.builder()
+			.set(DataComponents.PROFILE, newProfile)
+			.build();
+		applyComponents(collectComponents(), patch);
+	}
+
 	public SkullCandles getCandleInfo() {
 		return this.candleInfo;
+	}
+
+	public void setCandleInfo(SkullCandles newInfo) {
+		DataComponentPatch patch = DataComponentPatch.builder()
+			.set(TFDataComponents.SKULL_CANDLES.get(), newInfo)
+			.build();
+		applyComponents(collectComponents(), patch);
 	}
 }

--- a/src/main/java/twilightforest/client/renderer/block/SkullCandleRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/block/SkullCandleRenderer.java
@@ -25,7 +25,6 @@ import net.minecraft.world.level.block.SkullBlock;
 import net.minecraft.world.level.block.WallSkullBlock;
 import net.minecraft.world.level.block.entity.SkullBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
 import org.jspecify.annotations.Nullable;
@@ -92,7 +91,7 @@ public class SkullCandleRenderer implements BlockEntityRenderer<SkullCandleBlock
 		state.skullType = ((AbstractSkullBlock)blockState.getBlock()).getType();
 		state.renderType = this.resolveSkullRenderType(state.skullType, blockEntity);
 
-		updateSkullCandle(blockEntity.candleInfo, this.blockResolver, state.candle, blockState.getValue(AbstractSkullCandleBlock.LIGHTING) != LightableBlock.Lighting.NONE);
+		updateSkullCandle(blockEntity.getCandleInfo(), this.blockResolver, state.candle, blockState.getValue(AbstractSkullCandleBlock.LIGHTING) != LightableBlock.Lighting.NONE);
 	}
 
 	public static void updateSkullCandle(SkullCandles info, BlockModelResolver resolver, BlockModelRenderState state, boolean lit) {

--- a/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
+++ b/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
@@ -1,8 +1,6 @@
 package twilightforest.dispenser;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.component.DataComponentPatch;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.dispenser.BlockSource;
 import net.minecraft.core.dispenser.OptionalDispenseItemBehavior;
 import net.minecraft.server.level.ServerLevel;
@@ -22,7 +20,6 @@ import twilightforest.block.entity.CandelabraBlockEntity;
 import twilightforest.block.entity.SkullCandleBlockEntity;
 import twilightforest.components.item.SkullCandles;
 import twilightforest.init.TFBlocks;
-import twilightforest.init.TFDataComponents;
 
 public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 
@@ -123,11 +120,8 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 				.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
 				.setValue(SkullCandleBlock.ROTATION, level.getBlockState(pos).getValue(SkullBlock.ROTATION))));
 		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) {
-			DataComponentPatch patch = DataComponentPatch.builder()
-				.set(TFDataComponents.SKULL_CANDLES.get(), new SkullCandles(sc.getCandleInfo().count(), AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()))
-				.set(DataComponents.PROFILE, profile)
-				.build();
-			sc.applyComponents(sc.collectComponents(), patch);
+			sc.setCandleInfo(new SkullCandles(sc.getCandleInfo().count(), AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()));
+			sc.setOwnerProfile(profile);
 			sc.setChanged();
 		}
 	}
@@ -143,11 +137,8 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 				.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
 				.setValue(WallSkullCandleBlock.FACING, level.getBlockState(pos).getValue(WallSkullBlock.FACING))));
 		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) {
-			DataComponentPatch patch = DataComponentPatch.builder()
-				.set(TFDataComponents.SKULL_CANDLES.get(), new SkullCandles(sc.getCandleInfo().count(), AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()))
-				.set(DataComponents.PROFILE, profile)
-				.build();
-			sc.applyComponents(sc.collectComponents(), patch);
+			sc.setCandleInfo(new SkullCandles(sc.getCandleInfo().count(), AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()));
+			sc.setOwnerProfile(profile);
 			sc.setChanged();
 		}
 	}

--- a/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
+++ b/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
@@ -41,7 +41,7 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 
 	private static boolean tryAddCandle(ServerLevel level, BlockPos pos, Item candle) {
 		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) {
-			if (candle == AbstractSkullCandleBlock.candleColorToCandle(AbstractSkullCandleBlock.CandleColors.colorFromInt(sc.getCandleColor())).asItem()) {
+			if (candle == AbstractSkullCandleBlock.candleColorToCandle(AbstractSkullCandleBlock.CandleColors.colorFromInt(sc.candleInfo.color())).asItem()) {
 				BlockState state = level.getBlockState(pos);
 				int candles = state.getValue(BlockStateProperties.CANDLES);
 				if (candles < 4) {
@@ -117,8 +117,8 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 		level.setBlockEntity(new SkullCandleBlockEntity(pos,
 			newBlock.defaultBlockState()
 				.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
-				.setValue(SkullCandleBlock.ROTATION, level.getBlockState(pos).getValue(SkullBlock.ROTATION)),
-			AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()));
+				.setValue(SkullCandleBlock.ROTATION, level.getBlockState(pos).getValue(SkullBlock.ROTATION))));
+		// TODO: Deal with removal of .setOwner()
 		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) sc.setOwner(profile);
 	}
 
@@ -131,8 +131,8 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 		level.setBlockEntity(new SkullCandleBlockEntity(pos,
 			newBlock.defaultBlockState()
 				.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
-				.setValue(WallSkullCandleBlock.FACING, level.getBlockState(pos).getValue(WallSkullBlock.FACING)),
-			AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()));
+				.setValue(WallSkullCandleBlock.FACING, level.getBlockState(pos).getValue(WallSkullBlock.FACING))));
+		// TODO: Deal with removal of .setOwner()
 		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) sc.setOwner(profile);
 	}
 }

--- a/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
+++ b/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
@@ -1,6 +1,8 @@
 package twilightforest.dispenser;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.dispenser.BlockSource;
 import net.minecraft.core.dispenser.OptionalDispenseItemBehavior;
 import net.minecraft.server.level.ServerLevel;
@@ -18,7 +20,9 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import twilightforest.block.*;
 import twilightforest.block.entity.CandelabraBlockEntity;
 import twilightforest.block.entity.SkullCandleBlockEntity;
+import twilightforest.components.item.SkullCandles;
 import twilightforest.init.TFBlocks;
+import twilightforest.init.TFDataComponents;
 
 public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 
@@ -41,7 +45,7 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 
 	private static boolean tryAddCandle(ServerLevel level, BlockPos pos, Item candle) {
 		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) {
-			if (candle == AbstractSkullCandleBlock.candleColorToCandle(AbstractSkullCandleBlock.CandleColors.colorFromInt(sc.candleInfo.color())).asItem()) {
+			if (candle == AbstractSkullCandleBlock.candleColorToCandle(AbstractSkullCandleBlock.CandleColors.colorFromInt(sc.getCandleInfo().color())).asItem()) {
 				BlockState state = level.getBlockState(pos);
 				int candles = state.getValue(BlockStateProperties.CANDLES);
 				if (candles < 4) {
@@ -118,8 +122,14 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 			newBlock.defaultBlockState()
 				.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
 				.setValue(SkullCandleBlock.ROTATION, level.getBlockState(pos).getValue(SkullBlock.ROTATION))));
-		// TODO: Deal with removal of .setOwner()
-		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) sc.setOwner(profile);
+		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) {
+			DataComponentPatch patch = DataComponentPatch.builder()
+				.set(TFDataComponents.SKULL_CANDLES.get(), new SkullCandles(sc.getCandleInfo().count(), AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()))
+				.set(DataComponents.PROFILE, profile)
+				.build();
+			sc.applyComponents(sc.collectComponents(), patch);
+			sc.setChanged();
+		}
 	}
 
 	private static void makeWallSkull(Level level, BlockPos pos, Block newBlock, Item candle) {
@@ -132,7 +142,13 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 			newBlock.defaultBlockState()
 				.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
 				.setValue(WallSkullCandleBlock.FACING, level.getBlockState(pos).getValue(WallSkullBlock.FACING))));
-		// TODO: Deal with removal of .setOwner()
-		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) sc.setOwner(profile);
+		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) {
+			DataComponentPatch patch = DataComponentPatch.builder()
+				.set(TFDataComponents.SKULL_CANDLES.get(), new SkullCandles(sc.getCandleInfo().count(), AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()))
+				.set(DataComponents.PROFILE, profile)
+				.build();
+			sc.applyComponents(sc.collectComponents(), patch);
+			sc.setChanged();
+		}
 	}
 }

--- a/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
+++ b/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
@@ -115,10 +115,9 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 		level.setBlockAndUpdate(pos, newBlock.defaultBlockState()
 			.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
 			.setValue(SkullCandleBlock.ROTATION, level.getBlockState(pos).getValue(SkullBlock.ROTATION)));
-		level.setBlockEntity(new SkullCandleBlockEntity(pos,
-			newBlock.defaultBlockState()
-				.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
-				.setValue(SkullCandleBlock.ROTATION, level.getBlockState(pos).getValue(SkullBlock.ROTATION))));
+		level.setBlockEntity(new SkullCandleBlockEntity(pos, newBlock.defaultBlockState()
+			.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
+			.setValue(SkullCandleBlock.ROTATION, level.getBlockState(pos).getValue(SkullBlock.ROTATION))));
 		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) {
 			sc.setCandleInfo(new SkullCandles(sc.getCandleInfo().count(), AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()));
 			sc.setOwnerProfile(profile);
@@ -132,10 +131,9 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 		level.setBlockAndUpdate(pos, newBlock.defaultBlockState()
 			.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
 			.setValue(WallSkullCandleBlock.FACING, level.getBlockState(pos).getValue(WallSkullBlock.FACING)));
-		level.setBlockEntity(new SkullCandleBlockEntity(pos,
-			newBlock.defaultBlockState()
-				.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
-				.setValue(WallSkullCandleBlock.FACING, level.getBlockState(pos).getValue(WallSkullBlock.FACING))));
+		level.setBlockEntity(new SkullCandleBlockEntity(pos, newBlock.defaultBlockState()
+			.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)
+			.setValue(WallSkullCandleBlock.FACING, level.getBlockState(pos).getValue(WallSkullBlock.FACING))));
 		if (level.getBlockEntity(pos) instanceof SkullCandleBlockEntity sc) {
 			sc.setCandleInfo(new SkullCandles(sc.getCandleInfo().count(), AbstractSkullCandleBlock.candleToCandleColor(candle).getValue()));
 			sc.setOwnerProfile(profile);

--- a/src/main/java/twilightforest/dispenser/CrumbleDispenseBehavior.java
+++ b/src/main/java/twilightforest/dispenser/CrumbleDispenseBehavior.java
@@ -4,10 +4,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.dispenser.BlockSource;
 import net.minecraft.core.dispenser.DefaultDispenseItemBehavior;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.DispenserBlock;
@@ -25,7 +22,7 @@ public class CrumbleDispenseBehavior extends DefaultDispenseItemBehavior {
 		BlockPos pos = source.pos().relative(source.state().getValue(DispenserBlock.FACING));
 		BlockState state = level.getBlockState(pos);
 		if (!(stack.getMaxDamage() == stack.getDamageValue() + 1)) {
-			var resultBlock = state.getBlock().builtInRegistryHolder().getData(TFDataMaps.CRUMBLE_HORN);
+			var resultBlock = state.typeHolder().getData(TFDataMaps.CRUMBLE_HORN);
 			if (resultBlock != null) {
 				if (resultBlock.result() == Blocks.AIR) {
 					level.destroyBlock(pos, true);
@@ -34,7 +31,7 @@ public class CrumbleDispenseBehavior extends DefaultDispenseItemBehavior {
 					level.levelEvent(LevelEvent.PARTICLES_DESTROY_BLOCK, pos, Block.getId(state));
 				}
 
-				stack.hurtAndBreak(1, level, null, item -> {});
+				stack.hurtAndBreak(1, level, null, _ -> {});
 				this.fired = true;
 			}
 		}

--- a/src/main/java/twilightforest/dispenser/FeatherFanDispenseBehavior.java
+++ b/src/main/java/twilightforest/dispenser/FeatherFanDispenseBehavior.java
@@ -34,7 +34,7 @@ public class FeatherFanDispenseBehavior extends DefaultDispenseItemBehavior {
 		List<LivingEntity> thingsToPush = level.getEntitiesOfClass(LivingEntity.class, new AABB(blockpos).inflate(3), EntitySelector.NO_SPECTATORS);
 		if (!(thingsToPush.size() >= damage)) {
 			for (Entity entity : thingsToPush) {
-				Vec3i lookVec = level.getBlockState(source.pos()).getValue(DispenserBlock.FACING).getNormal();
+				Vec3i lookVec = level.getBlockState(source.pos()).getValue(DispenserBlock.FACING).getUnitVec3i();
 
 				if (entity.isPushable() || entity instanceof ItemEntity) {
 					entity.setDeltaMovement(lookVec.getX(), lookVec.getY(), lookVec.getZ());

--- a/src/main/java/twilightforest/dispenser/TFDispenserBehaviors.java
+++ b/src/main/java/twilightforest/dispenser/TFDispenserBehaviors.java
@@ -1,12 +1,10 @@
 package twilightforest.dispenser;
 
 import net.minecraft.core.Position;
-import net.minecraft.core.dispenser.BlockSource;
 import net.minecraft.core.dispenser.DispenseItemBehavior;
-import net.minecraft.core.dispenser.OptionalDispenseItemBehavior;
+import net.minecraft.core.dispenser.EquipmentDispenseItemBehavior;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.projectile.Projectile;
-import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
@@ -37,13 +35,7 @@ public class TFDispenserBehaviors {
 			}
 		});
 
-		DispenseItemBehavior idispenseitembehavior = new OptionalDispenseItemBehavior() {
-			@Override
-			protected ItemStack execute(BlockSource source, ItemStack stack) {
-				this.setSuccess(ArmorItem.dispenseArmor(source, stack));
-				return stack;
-			}
-		};
+		DispenseItemBehavior idispenseitembehavior = EquipmentDispenseItemBehavior.INSTANCE;
 		DispenserBlock.registerBehavior(TFBlocks.NAGA_TROPHY.get().asItem(), idispenseitembehavior);
 		DispenserBlock.registerBehavior(TFBlocks.LICH_TROPHY.get().asItem(), idispenseitembehavior);
 		DispenserBlock.registerBehavior(TFBlocks.MINOSHROOM_TROPHY.get().asItem(), idispenseitembehavior);

--- a/src/main/java/twilightforest/events/EntityEvents.java
+++ b/src/main/java/twilightforest/events/EntityEvents.java
@@ -70,6 +70,7 @@ import tamaized.beanification.Autowired;
 import twilightforest.block.*;
 import twilightforest.block.entity.SkullCandleBlockEntity;
 import twilightforest.block.entity.SkullChestBlockEntity;
+import twilightforest.components.item.SkullCandles;
 import twilightforest.config.TFConfig;
 import twilightforest.tags.TFEntityTypeTags;
 import twilightforest.enchantment.ApplyFrostedEffect;
@@ -326,11 +327,13 @@ public class EntityEvents {
 		level.playSound(null, event.getPos(), SoundEvents.CANDLE_PLACE, SoundSource.BLOCKS, 1.0F, 1.0F);
 		level.setBlockAndUpdate(event.getPos(), newBlock.withPropertiesOf(level.getBlockState(event.getPos()))
 			.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE));
-		level.setBlockEntity(new SkullCandleBlockEntity(event.getPos(),
-			newBlock.withPropertiesOf(level.getBlockState(event.getPos()))
-				.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE),
-			AbstractSkullCandleBlock.candleToCandleColor(event.getItemStack().getItem()).getValue()));
-		if (level.getBlockEntity(event.getPos()) instanceof SkullCandleBlockEntity sc) sc.setOwner(profile);
+		level.setBlockEntity(new SkullCandleBlockEntity(event.getPos(), newBlock.withPropertiesOf(level.getBlockState(event.getPos()))
+			.setValue(AbstractSkullCandleBlock.LIGHTING, LightableBlock.Lighting.NONE)));
+		if (level.getBlockEntity(event.getPos()) instanceof SkullCandleBlockEntity sc) {
+			sc.setCandleInfo(new SkullCandles(sc.getCandleInfo().count(), AbstractSkullCandleBlock.candleToCandleColor(event.getItemStack().getItem()).getValue()));
+			sc.setOwnerProfile(profile);
+			sc.setChanged();
+		}
 	}
 
 	/**

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -266,3 +266,6 @@ public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity quickCh
 
 public net.minecraft.client.model.player.PlayerModel slim
 public net.minecraft.server.level.ServerPlayer synchronizeSpecialItemUpdates(Lnet/minecraft/world/item/ItemStack;)V
+
+# SkullCandleBlockEntity (Allows us to reuse "owner" from SkullBlockEntity)
+protected net.minecraft.world.level.block.entity.SkullBlockEntity owner


### PR DESCRIPTION
Largest changes are with the skull candle. The vanilla *SkullBlockEntity* made some fields private and moved further into the data component system, so I reflected those changes in *SkullCandleBlockEntity*. I also updated *CandleDispenseBehavior* to reflect an internal change, which removed color from the constructor of *SkullCandleBlockEntity* and moved it into the data component. Whoever made that change may want to review this PR. I also tried to clean up all the call sites my changes affected in the last commit.