### PR TITLE
compatibility to SimplySwords SoulTetherEffect

### DIFF
--- a/src/main/java/twilightforest/asmhooks/DamageSourceHooks.java
+++ b/src/main/java/twilightforest/asmhooks/DamageSourceHooks.java
@@ -16,6 +16,12 @@ public class DamageSourceHooks {
 	 * {@link net.minecraft.world.damagesource.DamageSources#playerAttack(Player)}
 	 */
 	public static DamageSource getCustomDamageSource(DamageSource o, LivingEntity entity) {
+		if (entitiy == null) {
+			// https://github.com/FTBTeam/FTB-Modpack-Issues/issues/12518
+			// SimplySwords propagates entity=null if LivingEntity is NOT a player.
+			// https://github.com/Sweenus/SimplySwords/blob/0bbb7cb0b4898c24b2425d3d5b29179c83deb4bf/common/src/main/java/net/sweenus/simplyswords/effect/SoulTetherEffect.java#L40
+			return o;
+		}
 		return entity.getWeaponItem().getItem() instanceof CustomDamageProvider customDamageType ? customDamageType.getDamageSource(entity) : o;
 	}
 


### PR DESCRIPTION
https://github.com/FTBTeam/FTB-Modpack-Issues/issues/12518
SimplySwords propagates entity=null for non-players which breaks getWeaponItem(). This code makes The Twilight Forest compatible to such behaviour.

Or define @NotNull entity and help to elegantly fix it there: https://github.com/Sweenus/SimplySwords/blob/0bbb7cb0b4898c24b2425d3d5b29179c83deb4bf/common/src/main/java/net/sweenus/simplyswords/effect/SoulTetherEffect.java#L40