### PR TITLE
Resolved FIXME(s) in EntityEvents

### DIFF
--- a/src/main/java/twilightforest/command/InfoCommand.java
+++ b/src/main/java/twilightforest/command/InfoCommand.java
@@ -14,7 +14,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.random.Weighted;
-import net.minecraft.util.random.WeightedList;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
@@ -26,6 +25,7 @@ import twilightforest.util.landmarks.LandmarkUtil;
 import twilightforest.world.components.structures.start.TFStructureStart;
 import twilightforest.world.components.structures.util.LandmarkStructure;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -78,11 +78,14 @@ public class InfoCommand {
 			}
 
 			// what is the spawn list
-			WeightedList<MobSpawnSettings.SpawnerData> spawnList = EntityEvents.gatherPotentialSpawns(level.structureManager(), MobCategory.MONSTER, pos);
-			source.sendSuccess(() -> Component.translatable("commands.tffeature.structure.spawn_list").withStyle(ChatFormatting.UNDERLINE), false);
-			if (spawnList != null)
-				for (Weighted<MobSpawnSettings.SpawnerData> entry : spawnList.unwrap())
-					source.sendSuccess(() -> Component.translatable("commands.tffeature.structure.spawn_info", entry.value().type().getDescription().getString(), entry.weight()), false);
+			List<Weighted<MobSpawnSettings.SpawnerData>> spawnList = new ArrayList<>();
+
+			EntityEvents.gatherPotentialSpawns(level.structureManager(), MobCategory.MONSTER, pos, spawnList::add);
+
+			if (!spawnList.isEmpty()) {
+				source.sendSuccess(() -> Component.translatable("commands.tffeature.structure.spawn_list").withStyle(ChatFormatting.UNDERLINE), false);
+				spawnList.forEach(entry -> source.sendSuccess(() -> Component.translatable("commands.tffeature.structure.spawn_info", entry.value().type().getDescription().getString(), entry.weight()), false));
+			}
 		} else {
 			source.sendSuccess(() -> Component.translatable("commands.tffeature.structure.outside").withStyle(ChatFormatting.BOLD, ChatFormatting.RED), false);
 		}

--- a/src/main/java/twilightforest/events/EntityEvents.java
+++ b/src/main/java/twilightforest/events/EntityEvents.java
@@ -12,7 +12,7 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.tags.ItemTags;
-import net.minecraft.util.random.WeightedList;
+import net.minecraft.util.random.Weighted;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
@@ -62,7 +62,6 @@ import net.neoforged.neoforge.event.level.ExplosionEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
 import net.neoforged.neoforge.items.ItemHandlerHelper;
 import net.neoforged.neoforge.network.PacketDistributor;
-import org.jetbrains.annotations.Nullable;
 import tamaized.beanification.PostConstruct;
 import twilightforest.TwilightForestMod;
 import twilightforest.advancements.DrinkFromFlaskTrigger;
@@ -88,11 +87,13 @@ import twilightforest.util.entities.OminousFireDamageSource;
 import twilightforest.world.components.structures.SpawnIndexProvider;
 import twilightforest.world.components.structures.finalcastle.FinalCastleBossGazeboComponent;
 import twilightforest.world.components.structures.start.TFStructureStart;
-import twilightforest.world.components.structures.type.HollowHillStructure;
 import twilightforest.world.components.structures.util.ControlledSpawns;
+import twilightforest.world.components.structures.util.ValidatedSpawnLocations;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 @tamaized.beanification.Component
 public class EntityEvents {
@@ -369,45 +370,58 @@ public class EntityEvents {
 		return highestFoundIndex;
 	}
 
-	@Nullable
-	public static WeightedList<MobSpawnSettings.SpawnerData> gatherPotentialSpawns(StructureManager structureManager, MobCategory classification, BlockPos pos) {
+	public static void gatherPotentialSpawns(StructureManager structureManager, MobCategory classification, BlockPos pos, Consumer<Weighted<MobSpawnSettings.SpawnerData>> consumer) {
 		List<StructureStart> structureStarts = structureManager.startsForStructure(ChunkPos.containing(pos), s -> s instanceof ControlledSpawns);
 
-		// This is wretched FIXME make this method return void instead, make one of parameters the SpawnerData consumer (eg LevelEvent.PotentialSpawns::addSpawnerData or List::add)
 		for (StructureStart start : structureStarts) {
 			if (start.getStructure() instanceof ControlledSpawns landmark) {
 
 				if (!start.isValid())
 					continue;
 
-				if (classification != MobCategory.MONSTER)
-					return landmark.getSpawnableList(classification);
+				if (classification != MobCategory.MONSTER) {
+					landmark.getSpawnableList(classification)
+						.unwrap()
+						.forEach(consumer);
+
+					return;
+				}
 
 				if (start instanceof TFStructureStart s && s.isConquered())
-					return null;
+					return;
 
-				// FIXME Make interface for this method?
-				if (landmark instanceof HollowHillStructure hollowHill && !hollowHill.canSpawnMob(pos, start.getBoundingBox()))
-					return null;
+				if (landmark instanceof ValidatedSpawnLocations validator && !validator.canSpawnMob(pos, start.getBoundingBox()))
+					return;
 
 				final int index = getSpawnListIndexAt(start, pos);
 				if (index < 0)
-					return null;
-				return landmark.getSpawnableMonsterList(index);
+					return;
+
+				landmark.getSpawnableMonsterList(index)
+					.unwrap()
+					.forEach(consumer);
+
+				return;
 			}
 		}
-
-		return null;
 	}
 
 	private void structureSpecialSpawns(LevelEvent.PotentialSpawns event) {
 		if (!(event.getLevel() instanceof ServerLevel serverLevel))
 			return;
 
-		WeightedList<MobSpawnSettings.SpawnerData> potentialStructureSpawns = gatherPotentialSpawns(serverLevel.structureManager(), event.getMobCategory(), event.getPos());
-		if (potentialStructureSpawns != null) {
+		List<Weighted<MobSpawnSettings.SpawnerData>> potentialStructureSpawns = new ArrayList<>();
+
+		gatherPotentialSpawns(
+			serverLevel.structureManager(),
+			event.getMobCategory(),
+			event.getPos(),
+			potentialStructureSpawns::add
+		);
+
+		if (!potentialStructureSpawns.isEmpty()) {
 			List.copyOf(event.getSpawnerDataList()).forEach(event::removeSpawnerData);
-			potentialStructureSpawns.unwrap().forEach(event::addSpawnerData);
+			potentialStructureSpawns.forEach(event::addSpawnerData);
 		}
 	}
 

--- a/src/main/java/twilightforest/world/components/structures/type/HollowHillStructure.java
+++ b/src/main/java/twilightforest/world/components/structures/type/HollowHillStructure.java
@@ -34,13 +34,14 @@ import twilightforest.world.components.structures.StructureSpeleothemConfig;
 import twilightforest.world.components.structures.util.ConfigurableSpawns;
 import twilightforest.world.components.structures.util.ControlledSpawns;
 import twilightforest.world.components.structures.util.LandmarkStructure;
+import twilightforest.world.components.structures.util.ValidatedSpawnLocations;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class HollowHillStructure extends LandmarkStructure implements ConfigurableSpawns, CustomDensitySource {
+public class HollowHillStructure extends LandmarkStructure implements ConfigurableSpawns, CustomDensitySource, ValidatedSpawnLocations {
 	public static final MapCodec<HollowHillStructure> CODEC = RecordCodecBuilder.mapCodec(instance -> instance
 		.group(
 			// TODO Clean up findGenerationPoint() first before even thinking about increasing upper limit
@@ -64,6 +65,7 @@ public class HollowHillStructure extends LandmarkStructure implements Configurab
 	}
 
 	// "Cuts" the box into a half-dome
+	@Override
 	public boolean canSpawnMob(BlockPos spawnPos, BoundingBox structureStartBox) {
 		float hX = Mth.inverseLerp(spawnPos.getX(), structureStartBox.minX(), structureStartBox.maxX()) * 2 - 1;
 		float hY = Mth.inverseLerp(spawnPos.getY(), structureStartBox.minY(), structureStartBox.maxY());

--- a/src/main/java/twilightforest/world/components/structures/util/ValidatedSpawnLocations.java
+++ b/src/main/java/twilightforest/world/components/structures/util/ValidatedSpawnLocations.java
@@ -1,0 +1,8 @@
+package twilightforest.world.components.structures.util;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+
+public interface ValidatedSpawnLocations {
+	boolean canSpawnMob(BlockPos pos, BoundingBox structureBounds);
+}


### PR DESCRIPTION
Addresses two FIXME(s) in *EntityEvents*. I tried to follow what the comments said as closely as possible, but do let me know if you would like something to be implemented differently. It is possible to avoid the temporary allocation in *InfoCommand* by having *gatherPotentialSpawns(...)* return a flag or by always printing the header regardless of the whether the list is populated or not. It's just a command though, so the impact is likely negligible.