### PR TITLE
Refactor traveller's recipes to use Holder<T> and port to 26.1.x

### DIFF
--- a/src/main/java/twilightforest/init/TFRecipes.java
+++ b/src/main/java/twilightforest/init/TFRecipes.java
@@ -11,7 +11,6 @@ import twilightforest.item.recipe.travellers.TravellersGearModifierShapedRecipe;
 import twilightforest.item.recipe.travellers.TravellersGearModifierShapelessRecipe;
 import twilightforest.item.recipe.travellers.TravellersVestGlovesMergeRecipe;
 
-// TODO: Update recipes to use new codec serialization system. Check RecipeSerializers and ShapedRecipe classes for reference implementation.
 public class TFRecipes {
 	public static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(Registries.RECIPE_SERIALIZER, TwilightForestMod.ID);
 	public static final DeferredRegister<RecipeType<?>> RECIPE_TYPES = DeferredRegister.create(Registries.RECIPE_TYPE, TwilightForestMod.ID);
@@ -24,8 +23,8 @@ public class TFRecipes {
 	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<MoonwormQueenRepairRecipe>> MOONWORM_QUEEN_REPAIR_RECIPE = RECIPE_SERIALIZERS.register("moonworm_queen_repair_recipe", () -> MoonwormQueenRepairRecipe.SERIALIZER);
 	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<ScepterRepairRecipe>> SCEPTER_REPAIR_RECIPE = RECIPE_SERIALIZERS.register("scepter_repair", () -> ScepterRepairRecipe.SERIALIZER);
 	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<UncraftingRecipe>> UNCRAFTING_SERIALIZER = RECIPE_SERIALIZERS.register("uncrafting", () -> UncraftingRecipe.SERIALIZER);
-	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<TravellersGearModifierShapelessRecipe>> MODIFIER_SHAPELESS_RECIPE_SERIALIZER = RECIPE_SERIALIZERS.register("travellers_gear_modifier_shapeless_recipe", TravellersGearModifierShapelessRecipe.Serializer::new);
-	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<TravellersGearModifierShapedRecipe>> MODIFIER_SHAPED_RECIPE_SERIALIZER = RECIPE_SERIALIZERS.register("travellers_gear_modifier_shaped_recipe", TravellersGearModifierShapedRecipe.Serializer::new);
+	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<TravellersGearModifierShapelessRecipe>> MODIFIER_SHAPELESS_RECIPE_SERIALIZER = RECIPE_SERIALIZERS.register("travellers_gear_modifier_shapeless_recipe", () -> TravellersGearModifierShapelessRecipe.SERIALIZER);
+	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<TravellersGearModifierShapedRecipe>> MODIFIER_SHAPED_RECIPE_SERIALIZER = RECIPE_SERIALIZERS.register("travellers_gear_modifier_shaped_recipe", () -> TravellersGearModifierShapedRecipe.SERIALIZER);
 	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<TravellersVestGlovesMergeRecipe>> TRAVELLERS_VEST_GLOVES_MERGE_RECIPE_SERIALIZER = RECIPE_SERIALIZERS.register("travellers_vest_gloves_merge_recipe", () -> TravellersVestGlovesMergeRecipe.SERIALIZER);
 	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<NoTemplateSmithingRecipe>> NO_TEMPLATE_SMITHING_SERIALIZER = RECIPE_SERIALIZERS.register("no_template_smithing", () -> NoTemplateSmithingRecipe.SERIALIZER);
 	public static final DeferredHolder<RecipeSerializer<?>, RecipeSerializer<DryingRecipe>> DRYING_SERIALIZER = RECIPE_SERIALIZERS.register("drying", () -> DryingRecipe.SERIALIZER);

--- a/src/main/java/twilightforest/init/custom/TravellersModifiersManager.java
+++ b/src/main/java/twilightforest/init/custom/TravellersModifiersManager.java
@@ -15,7 +15,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
-import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.level.Level;
 import twilightforest.TFRegistries;
 import twilightforest.TwilightForestMod;
@@ -105,19 +105,19 @@ public class TravellersModifiersManager {
 		return List.of(Component.translatable(modifier.identifier().toLanguageKey("travellers_gear.modifier", "description"), args));
 	}
 
-	public static boolean isModifierActive(ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder, boolean spectator) {
+	public static boolean isModifierActive(ItemStack stack, Holder<TravellersModifier> modifierHolder, boolean spectator) {
 		return modifierHolder.value().isActive(stack, modifierHolder, spectator);
 	}
 
-	public static boolean isModifierActive(Entity entity, ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder) {
+	public static boolean isModifierActive(Entity entity, ItemStack stack, Holder<TravellersModifier> modifierHolder) {
 		return isModifierActive(stack, modifierHolder, entity.isSpectator());
 	}
 
-	public static boolean isModifierActive(Entity entity, Holder.Reference<TravellersModifier> modifierHolder) {
+	public static boolean isModifierActive(Entity entity, Holder<TravellersModifier> modifierHolder) {
 		return entity instanceof LivingEntity livingEntity && isModifierActive(livingEntity, modifierHolder);
 	}
 
-	public static boolean isModifierActive(LivingEntity livingEntity, Holder.Reference<TravellersModifier> modifierHolder) {
+	public static boolean isModifierActive(LivingEntity livingEntity, Holder<TravellersModifier> modifierHolder) {
 		ItemStack equippedStack = getStackForGroup(livingEntity, modifierHolder.value().group());
 
 		return !equippedStack.isEmpty()
@@ -128,26 +128,26 @@ public class TravellersModifiersManager {
 		);
 	}
 
-	public static boolean hasTravellersModifier(ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder) {
+	public static boolean hasTravellersModifier(ItemStack stack, Holder<TravellersModifier> modifierHolder) {
 		return modifierHolder.value().hasModifier(stack);
 	}
 
-	public static boolean addModifier(ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder) {
+	public static boolean addModifier(ItemStack stack, Holder<TravellersModifier> modifierHolder) {
 		if (!(modifierHolder.value() instanceof InsertableTravellersModifier insertableTravellersModifier))
 			return false;
 		return insertableTravellersModifier.addModifier(stack);
 	}
 
-	public static boolean transferModifier(ItemStack stack, List<Ingredient> ingredients, Holder.Reference<TravellersModifier> modifierHolder) {
+	public static boolean transferModifier(ItemStack stack, CraftingInput input, Holder<TravellersModifier> modifierHolder) {
 		if (!(modifierHolder.value() instanceof TransferableTravellersModifier transferableTravellersModifier))
 			return false;
-		return transferableTravellersModifier.transfer(stack, ingredients);
+		return transferableTravellersModifier.transfer(stack, input);
 	}
 
-	public static int getModifierDataComponentProviders(List<Ingredient> ingredients, Holder.Reference<TravellersModifier> modifierHolder) {
+	public static int getModifierDataComponentProviders(CraftingInput input, Holder<TravellersModifier> modifierHolder) {
 		if (!(modifierHolder.value() instanceof TransferableComponentModifier transferableComponentModifier))
 			return 0;
-		return transferableComponentModifier.findDataComponentProviders(ingredients).size();
+		return transferableComponentModifier.findDataComponentProviders(input).size();
 	}
 
 	public static MutableComponent getModifierTooltipComponent(Holder.Reference<TravellersModifier> modifier) {

--- a/src/main/java/twilightforest/init/custom/TravellersModifiersManager.java
+++ b/src/main/java/twilightforest/init/custom/TravellersModifiersManager.java
@@ -26,6 +26,7 @@ import twilightforest.item.travellers_gear.TravellersArmorBeltItem;
 import twilightforest.item.travellers_gear.modifiers.*;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public class TravellersModifiersManager {
@@ -118,10 +119,11 @@ public class TravellersModifiersManager {
 	}
 
 	public static boolean isModifierActive(LivingEntity livingEntity, Holder<TravellersModifier> modifierHolder) {
-		ItemStack equippedStack = getStackForGroup(livingEntity, modifierHolder.value().group());
+		TravellersModifier modifier = modifierHolder.value();
+		ItemStack equippedStack = getStackForGroup(livingEntity, modifier.group());
 
 		return !equippedStack.isEmpty()
-			&& modifierHolder.value().isActive(
+			&& modifier.isActive(
 			equippedStack,
 			modifierHolder,
 			livingEntity.isSpectator()
@@ -151,7 +153,7 @@ public class TravellersModifiersManager {
 	}
 
 	public static MutableComponent getModifierTooltipComponent(Holder<TravellersModifier> modifier) {
-		return TooltipStringInterpolator.render(modifier.getKey().identifier().toLanguageKey(modifier.value().getPrefix()));
+		return TooltipStringInterpolator.render(getKeyOrThrow(modifier).identifier().toLanguageKey(modifier.value().getPrefix()));
 	}
 
 	public static List<Holder.Reference<TravellersModifier>> findAllInsertableModifiers(HolderLookup.Provider registries, ItemStack stack) {
@@ -172,6 +174,27 @@ public class TravellersModifiersManager {
 
 	public static long countInsertableModifiers(HolderLookup.Provider registries, ItemStack stack) {
 		return findAllInsertableModifiers(registries, stack).size();
+	}
+
+	// May or may not need this, we will see
+	public static Optional<Holder.Reference<TravellersModifier>> lookupHolder(HolderLookup.Provider registries, ResourceKey<TravellersModifier> key) {
+		Optional<Holder.Reference<TravellersModifier>> holder = registries.holder(key);
+
+		if (holder.isEmpty()) {
+			TwilightForestMod.LOGGER.warn("Travellers modifier {} is not present in the registry", key.identifier());
+		}
+
+		return holder;
+	}
+
+	public static ResourceKey<TravellersModifier> getKeyOrThrow(Holder<TravellersModifier> holder) {
+		return holder.unwrapKey().orElseThrow(() -> {
+			TwilightForestMod.LOGGER.error(
+				"Expected a registry-backed TravellersModifier holder but received {}",
+				holder
+			);
+			return new IllegalStateException("TravellersModifier holder is not registry-backed");
+		});
 	}
 
 	private static ItemStack getStackForGroup(LivingEntity livingEntity, EquipmentSlotGroup group) {

--- a/src/main/java/twilightforest/init/custom/TravellersModifiersManager.java
+++ b/src/main/java/twilightforest/init/custom/TravellersModifiersManager.java
@@ -7,10 +7,7 @@ import net.minecraft.data.worldgen.BootstrapContext;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
 import net.minecraft.util.Unit;
-import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.EquipmentSlotGroup;
@@ -29,10 +26,7 @@ import twilightforest.item.travellers_gear.TravellersArmorBeltItem;
 import twilightforest.item.travellers_gear.modifiers.*;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class TravellersModifiersManager {
 
@@ -68,9 +62,6 @@ public class TravellersModifiersManager {
 	public static final ResourceKey<TravellersModifier> WATER_WALK_MODIFIER = makeKey("water_walk");
 
 	public static final Set<ResourceKey<TravellersModifier>> ALWAYS_ACTIVE = Set.of(AUTO_REPAIR_MODIFIER);
-
-	private static final Map<ResourceKey<TravellersModifier>, TravellersModifier> CACHED_MODIFIERS = new ConcurrentHashMap<>();
-	private static final Set<ResourceKey<TravellersModifier>> MISSING_MODIFIERS = ConcurrentHashMap.newKeySet();
 
 	private static ResourceKey<TravellersModifier> makeKey(String name) {
 		return ResourceKey.create(TFRegistries.Keys.TRAVELLERS_MODIFIERS, TwilightForestMod.prefix(name));
@@ -114,47 +105,47 @@ public class TravellersModifiersManager {
 		return List.of(Component.translatable(modifier.identifier().toLanguageKey("travellers_gear.modifier", "description"), args));
 	}
 
-	public static boolean isModifierActive(HolderLookup.Provider registries, ItemStack stack, ResourceKey<TravellersModifier> modifierKey, boolean spectator) {
-		return getCachedModifier(registries, modifierKey).map(modifier -> modifier.isActive(stack, modifierKey, spectator)).orElse(false);
+	public static boolean isModifierActive(ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder, boolean spectator) {
+		return modifierHolder.value().isActive(stack, modifierHolder, spectator);
 	}
 
-	public static boolean isModifierActive(Entity entity, ItemStack stack, ResourceKey<TravellersModifier> modifierKey) {
-		return isModifierActive(entity.registryAccess(), stack, modifierKey, entity.isSpectator());
+	public static boolean isModifierActive(Entity entity, ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder) {
+		return isModifierActive(stack, modifierHolder, entity.isSpectator());
 	}
 
-	public static boolean isModifierActive(Entity entity, ResourceKey<TravellersModifier> modifierKey) {
-		return entity instanceof LivingEntity livingEntity && isModifierActive(livingEntity, modifierKey);
+	public static boolean isModifierActive(Entity entity, Holder.Reference<TravellersModifier> modifierHolder) {
+		return entity instanceof LivingEntity livingEntity && isModifierActive(livingEntity, modifierHolder);
 	}
 
-	public static boolean isModifierActive(LivingEntity livingEntity, ResourceKey<TravellersModifier> modifierKey) {
-		Optional<TravellersModifier> modifier = getCachedModifier(livingEntity.registryAccess(), modifierKey);
-		if (modifier.isEmpty())
-			return false;
-		ItemStack equippedStack = getStackForGroup(livingEntity, modifier.get().group());
-		return !equippedStack.isEmpty() && modifier.get().isActive(equippedStack, modifierKey, livingEntity.isSpectator());
+	public static boolean isModifierActive(LivingEntity livingEntity, Holder.Reference<TravellersModifier> modifierHolder) {
+		ItemStack equippedStack = getStackForGroup(livingEntity, modifierHolder.value().group());
+
+		return !equippedStack.isEmpty()
+			&& modifierHolder.value().isActive(
+			equippedStack,
+			modifierHolder,
+			livingEntity.isSpectator()
+		);
 	}
 
-	public static boolean hasTravellersModifier(HolderLookup.Provider registries, ItemStack stack, ResourceKey<TravellersModifier> modifierKey) {
-		return getCachedModifier(registries, modifierKey).map(modifier -> modifier.hasModifier(stack)).orElse(false);
+	public static boolean hasTravellersModifier(ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder) {
+		return modifierHolder.value().hasModifier(stack);
 	}
 
-	public static boolean addModifier(HolderLookup.Provider registries, ItemStack stack, ResourceKey<TravellersModifier> modifierKey) {
-		Optional<TravellersModifier> modifier = getCachedModifier(registries, modifierKey);
-		if (modifier.isEmpty() || !(modifier.get() instanceof InsertableTravellersModifier insertableTravellersModifier))
+	public static boolean addModifier(ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder) {
+		if (!(modifierHolder.value() instanceof InsertableTravellersModifier insertableTravellersModifier))
 			return false;
 		return insertableTravellersModifier.addModifier(stack);
 	}
 
-	public static boolean transferModifier(HolderLookup.Provider registries, ItemStack stack, List<Ingredient> ingredients, ResourceKey<TravellersModifier> modifierKey) {
-		Optional<TravellersModifier> modifier = getCachedModifier(registries, modifierKey);
-		if (modifier.isEmpty() || !(modifier.get() instanceof TransferableTravellersModifier transferableTravellersModifier))
+	public static boolean transferModifier(ItemStack stack, List<Ingredient> ingredients, Holder.Reference<TravellersModifier> modifierHolder) {
+		if (!(modifierHolder.value() instanceof TransferableTravellersModifier transferableTravellersModifier))
 			return false;
 		return transferableTravellersModifier.transfer(stack, ingredients);
 	}
 
-	public static int getModifierDataComponentProviders(HolderLookup.Provider registries, List<Ingredient> ingredients, ResourceKey<TravellersModifier> modifierKey) {
-		Optional<TravellersModifier> modifier = getCachedModifier(registries, modifierKey);
-		if (modifier.isEmpty() || !(modifier.get() instanceof TransferableComponentModifier transferableComponentModifier))
+	public static int getModifierDataComponentProviders(List<Ingredient> ingredients, Holder.Reference<TravellersModifier> modifierHolder) {
+		if (!(modifierHolder.value() instanceof TransferableComponentModifier transferableComponentModifier))
 			return 0;
 		return transferableComponentModifier.findDataComponentProviders(ingredients).size();
 	}
@@ -183,10 +174,6 @@ public class TravellersModifiersManager {
 		return findAllInsertableModifiers(registries, stack).size();
 	}
 
-	public static boolean isModifierEnabled(HolderLookup.Provider registries, ResourceKey<TravellersModifier> modifierKey) {
-		return getCachedModifier(registries, modifierKey).isPresent();
-	}
-
 	private static ItemStack getStackForGroup(LivingEntity livingEntity, EquipmentSlotGroup group) {
 		EquipmentSlot matchedSlot = null;
 		for (EquipmentSlot slot : EquipmentSlot.values()) {
@@ -197,45 +184,5 @@ public class TravellersModifiersManager {
 			matchedSlot = slot;
 		}
 		return matchedSlot == null ? ItemStack.EMPTY : livingEntity.getItemBySlot(matchedSlot);
-	}
-
-	public static void clearCache() {
-		CACHED_MODIFIERS.clear();
-		MISSING_MODIFIERS.clear();
-	}
-
-	private static Optional<TravellersModifier> getCachedModifier(HolderLookup.Provider registries, ResourceKey<TravellersModifier> modifierKey) {
-		TravellersModifier cached = CACHED_MODIFIERS.get(modifierKey);
-		if (cached != null)
-			return Optional.of(cached);
-		if (MISSING_MODIFIERS.contains(modifierKey))
-			return Optional.empty();
-
-		Optional<Holder.Reference<TravellersModifier>> modifier = registries.holder(modifierKey);
-		if (modifier.isPresent()) {
-			CACHED_MODIFIERS.put(modifierKey, modifier.get().value());
-			return Optional.of(modifier.get().value());
-		}
-
-		TwilightForestMod.LOGGER.warn("Travellers modifier {} is not present in the registry", modifierKey.identifier());
-		MISSING_MODIFIERS.add(modifierKey);
-		return Optional.empty();
-	}
-
-	public static final class CacheInvalidationReloadListener extends SimplePreparableReloadListener<Unit> {
-		public static final CacheInvalidationReloadListener INSTANCE = new CacheInvalidationReloadListener();
-
-		private CacheInvalidationReloadListener() {
-		}
-
-		@Override
-		protected Unit prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
-			return Unit.INSTANCE;
-		}
-
-		@Override
-		protected void apply(Unit object, ResourceManager resourceManager, ProfilerFiller profiler) {
-			clearCache();
-		}
 	}
 }

--- a/src/main/java/twilightforest/init/custom/TravellersModifiersManager.java
+++ b/src/main/java/twilightforest/init/custom/TravellersModifiersManager.java
@@ -150,7 +150,7 @@ public class TravellersModifiersManager {
 		return transferableComponentModifier.findDataComponentProviders(input).size();
 	}
 
-	public static MutableComponent getModifierTooltipComponent(Holder.Reference<TravellersModifier> modifier) {
+	public static MutableComponent getModifierTooltipComponent(Holder<TravellersModifier> modifier) {
 		return TooltipStringInterpolator.render(modifier.getKey().identifier().toLanguageKey(modifier.value().getPrefix()));
 	}
 

--- a/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierRecipe.java
+++ b/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierRecipe.java
@@ -1,40 +1,28 @@
 package twilightforest.item.recipe.travellers;
 
-import com.google.gson.JsonElement;
-import com.mojang.serialization.JsonOps;
-import com.mojang.serialization.MapCodec;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.network.RegistryFriendlyByteBuf;
-import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.core.Holder;
 import net.minecraft.resources.Identifier;
-import net.minecraft.resources.RegistryOps;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.util.GsonHelper;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.Level;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
-import twilightforest.data.helpers.TFLangProvider;
 import twilightforest.init.custom.TravellersModifiersManager;
 import twilightforest.item.travellers_gear.modifiers.TravellersModifiable;
 import twilightforest.item.travellers_gear.modifiers.TravellersModifier;
 
 import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.List;
 import java.util.stream.StreamSupport;
 
-// TODO: Port to 26.1.X
 public abstract class TravellersGearModifierRecipe extends CustomRecipe {
-	protected final ResourceKey<TravellersModifier> travellersModifierKey;
-	public TravellersGearModifierRecipe(ResourceKey<TravellersModifier> travellersModifier) {
-		super(CraftingBookCategory.EQUIPMENT);
-		this.travellersModifierKey = travellersModifier;
+	protected final Holder<TravellersModifier> travellersModifierHolder;
+
+	public TravellersGearModifierRecipe(Holder<TravellersModifier> travellersModifierHolder) {
+		super();
+		this.travellersModifierHolder = travellersModifierHolder;
 	}
 
 	@Override
-	public boolean matches(@NotNull CraftingInput input, @NotNull Level level) {
+	public boolean matches(CraftingInput input, Level level) {
 		ItemStack stack = getModifiableArmor(input);
 		if (stack == null)
 			return false;
@@ -42,24 +30,29 @@ public abstract class TravellersGearModifierRecipe extends CustomRecipe {
 		if (stack.getItem() instanceof TravellersModifiable travellersModifiableItem)
 			slots = travellersModifiableItem.getModifierSlots();
 		return TravellersModifiersManager.countInsertableModifiers(level.registryAccess(), stack) < slots
-			&& !TravellersModifiersManager.hasTravellersModifier(level.registryAccess(), stack, this.travellersModifierKey)
-			&& TravellersModifiersManager.getModifierDataComponentProviders(level.registryAccess(), input.items().stream().map(Ingredient::of).toList(), this.travellersModifierKey) <= 1;
+			&& !TravellersModifiersManager.hasTravellersModifier(stack, this.travellersModifierHolder)
+			&& TravellersModifiersManager.getModifierDataComponentProviders(input, this.travellersModifierHolder) <= 1;
 	}
 
 	@Override
-	public ItemStack assemble(CraftingInput craftingInput) {
-		ItemStack travellerArmorStack = getModifiableArmor(craftingInput);
+	public ItemStack assemble(CraftingInput input) {
+		ItemStack travellerArmorStack = getModifiableArmor(input);
 		if (travellerArmorStack == null)
 			return ItemStack.EMPTY;  // Should never happen
 
 		ItemStack stack = travellerArmorStack.copy();
-		return applyModifier(registries, stack, craftingInput.items().stream().map(Ingredient::of).toList());
+		return applyModifier(stack, input);
 	}
 
-	public ItemStack applyModifier(HolderLookup.Provider registries, ItemStack stack, List<Ingredient> inputs) {
-		if (TravellersModifiersManager.transferModifier(registries, stack, inputs, this.travellersModifierKey))
+	@Override
+	public CraftingBookCategory category() {
+		return CraftingBookCategory.EQUIPMENT;
+	}
+
+	public ItemStack applyModifier(ItemStack stack, CraftingInput input) {
+		if (TravellersModifiersManager.transferModifier(stack, input, this.travellersModifierHolder))
 			return stack;
-		boolean modifierAdded = TravellersModifiersManager.addModifier(registries, stack, this.travellersModifierKey);
+		boolean modifierAdded = TravellersModifiersManager.addModifier(stack, this.travellersModifierHolder);
 		return modifierAdded ? stack : ItemStack.EMPTY;
 	}
 
@@ -80,48 +73,21 @@ public abstract class TravellersGearModifierRecipe extends CustomRecipe {
 
 	public static ItemStack getModifiableArmorFromIngredients(Iterable<Ingredient> ingredients) {
 		return StreamSupport.stream(ingredients.spliterator(), false)
-			.flatMap(ingredient -> Arrays.stream(ingredient.getItems()))
-			.filter(stack -> stack.getItem() instanceof TravellersModifiable).findFirst().orElseThrow();
+			.flatMap(Ingredient::items)
+			.map(ItemStack::new)
+			.filter(stack -> stack.getItem() instanceof TravellersModifiable)
+			.findFirst()
+			.orElseThrow();
 	}
 
 	public Identifier getId() {
-		return travellersModifierKey.identifier()
-			.withPrefix(StringUtils.substringAfterLast(getModifiableArmorFromIngredients(getIngredients()).getDescriptionId(), '.') + "/")
+		return travellersModifierHolder.unwrapKey().orElseThrow().identifier()
+			.withPrefix(StringUtils.substringAfterLast(getModifiableArmorFromIngredients(placementInfo().ingredients()).getItem().getDescriptionId(), '.') + "/")
 			.withPrefix("add_modifier_to_travellers_gear/")
 			.withSuffix("_modifier");
 	}
 
-	public ResourceKey<TravellersModifier> getTravellersModifierKey() {
-		return travellersModifierKey;
-	}
-
-	public static class AbstractModifierRecipeSerializer<T extends TravellersGearModifierRecipe> implements RecipeSerializer<T> {
-		protected final MapCodec<T> codec;
-
-		protected AbstractModifierRecipeSerializer(MapCodec<T> codec) {
-			this.codec = codec;
-		}
-
-		@Override
-		public @NotNull MapCodec<T> codec() {
-			return codec;
-		}
-
-		@Override
-		public @NotNull StreamCodec<RegistryFriendlyByteBuf, T> streamCodec() {
-			return StreamCodec.of(this::toNetwork, this::fromNetwork);
-		}
-
-		public T fromNetwork(RegistryFriendlyByteBuf buf) {
-			RegistryOps<JsonElement> registryops = buf.registryAccess().createSerializationContext(JsonOps.INSTANCE);
-			JsonElement jsonelementDeserialized = GsonHelper.fromJson(TFLangProvider.GSON, buf.readUtf(), JsonElement.class);
-			return codec.codec().decode(registryops, jsonelementDeserialized).getOrThrow().getFirst();
-		}
-
-		public void toNetwork(RegistryFriendlyByteBuf buf, T recipe) {
-			RegistryOps<JsonElement> registryops = buf.registryAccess().createSerializationContext(JsonOps.INSTANCE);
-			JsonElement jsonelement = codec.codec().encodeStart(registryops, recipe).getOrThrow();
-			buf.writeUtf(jsonelement.toString());
-		}
+	public Holder<TravellersModifier> getTravellersModifierHolder() {
+		return travellersModifierHolder;
 	}
 }

--- a/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierRecipe.java
+++ b/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierRecipe.java
@@ -3,7 +3,10 @@ package twilightforest.item.recipe.travellers;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.*;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingInput;
+import net.minecraft.world.item.crafting.CustomRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
 import org.apache.commons.lang3.StringUtils;
 import twilightforest.init.custom.TravellersModifiersManager;
@@ -75,7 +78,7 @@ public abstract class TravellersGearModifierRecipe extends CustomRecipe {
 		return StreamSupport.stream(ingredients.spliterator(), false)
 			.flatMap(Ingredient::items)
 			.map(ItemStack::new)
-			.filter(stack -> stack.getItem() instanceof TravellersModifiable)
+			.filter(stack -> stack.getItem() instanceof TravellersModifiable modifiable && modifiable.getModifierSlots() > 0)
 			.findFirst()
 			.orElseThrow();
 	}

--- a/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierRecipe.java
+++ b/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierRecipe.java
@@ -81,7 +81,7 @@ public abstract class TravellersGearModifierRecipe extends CustomRecipe {
 	}
 
 	public Identifier getId() {
-		return travellersModifierHolder.unwrapKey().orElseThrow().identifier()
+		return TravellersModifiersManager.getKeyOrThrow(travellersModifierHolder).identifier()
 			.withPrefix(StringUtils.substringAfterLast(getModifiableArmorFromIngredients(placementInfo().ingredients()).getItem().getDescriptionId(), '.') + "/")
 			.withPrefix("add_modifier_to_travellers_gear/")
 			.withSuffix("_modifier");

--- a/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierShapedRecipe.java
+++ b/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierShapedRecipe.java
@@ -1,28 +1,61 @@
 package twilightforest.item.recipe.travellers;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.Holder;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.Identifier;
-import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.RegistryFixedCodec;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.Level;
-import org.jetbrains.annotations.NotNull;
 import twilightforest.TFRegistries;
-import twilightforest.init.TFRecipes;
 import twilightforest.item.travellers_gear.modifiers.TravellersModifier;
 
 public class TravellersGearModifierShapedRecipe extends TravellersGearModifierRecipe {
+	public static final MapCodec<TravellersGearModifierShapedRecipe> MAP_CODEC = RecordCodecBuilder.mapCodec(instance ->
+		instance.group(
+			ShapedRecipePattern.MAP_CODEC
+				.fieldOf("pattern")
+				.forGetter(recipe -> recipe.pattern),
+			RegistryFixedCodec.create(TFRegistries.Keys.TRAVELLERS_MODIFIERS)
+				.fieldOf("modifier_key")
+				.forGetter(TravellersGearModifierRecipe::getTravellersModifierHolder),
+			Codec.BOOL
+				.fieldOf("is_rotated")
+				.forGetter(recipe -> recipe.isRotated)
+		).apply(instance, TravellersGearModifierShapedRecipe::new)
+	);
+
+	public static final StreamCodec<RegistryFriendlyByteBuf, TravellersGearModifierShapedRecipe> STREAM_CODEC =
+		StreamCodec.composite(
+			ShapedRecipePattern.STREAM_CODEC,
+			recipe -> recipe.pattern,
+
+			ByteBufCodecs.holderRegistry(TFRegistries.Keys.TRAVELLERS_MODIFIERS),
+			TravellersGearModifierRecipe::getTravellersModifierHolder,
+
+			ByteBufCodecs.BOOL,
+			recipe -> recipe.isRotated,
+
+			TravellersGearModifierShapedRecipe::new
+		);
+
+	public static final RecipeSerializer<TravellersGearModifierShapedRecipe> SERIALIZER = new RecipeSerializer<>(MAP_CODEC, STREAM_CODEC);
+
 	protected final ShapedRecipePattern pattern;
 	protected final boolean isRotated;
 
-	public TravellersGearModifierShapedRecipe(ShapedRecipePattern pattern, ResourceKey<TravellersModifier> travellersModifier, boolean isRotated) {
-		super(travellersModifier);
+	public TravellersGearModifierShapedRecipe(ShapedRecipePattern pattern, Holder<TravellersModifier> travellersModifierHolder, boolean isRotated) {
+		super(travellersModifierHolder);
 		this.pattern = pattern;
 		this.isRotated = isRotated;
 	}
 
 	@Override
-	public boolean matches(@NotNull CraftingInput input, @NotNull Level level) {
+	public boolean matches(CraftingInput input, Level level) {
 		if (!super.matches(input, level))
 			return false;
 		return pattern.matches(input);
@@ -55,22 +88,6 @@ public class TravellersGearModifierShapedRecipe extends TravellersGearModifierRe
 
 	@Override
 	public RecipeSerializer<? extends CustomRecipe> getSerializer() {
-		return TFRecipes.MODIFIER_SHAPED_RECIPE_SERIALIZER.get();
-	}
-
-	public static class Serializer extends AbstractModifierRecipeSerializer<TravellersGearModifierShapedRecipe> {
-		public Serializer() {
-			super(RecordCodecBuilder.mapCodec(instance -> instance.group(
-				ShapedRecipePattern.MAP_CODEC
-					.fieldOf("pattern")
-					.forGetter(recipe -> recipe.pattern),
-				ResourceKey.codec(TFRegistries.Keys.TRAVELLERS_MODIFIERS)
-					.fieldOf("modifier_key")
-					.forGetter(recipe -> recipe.travellersModifierKey),
-				Codec.BOOL
-					.fieldOf("is_rotated")
-					.forGetter(recipe -> recipe.isRotated)
-			).apply(instance, TravellersGearModifierShapedRecipe::new)));
-		}
+		return SERIALIZER;
 	}
 }

--- a/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierShapelessRecipe.java
+++ b/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierShapelessRecipe.java
@@ -1,29 +1,56 @@
 package twilightforest.item.recipe.travellers;
 
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.Holder;
 import net.minecraft.core.NonNullList;
-import net.minecraft.resources.ResourceKey;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.RegistryFixedCodec;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.Level;
-import org.jetbrains.annotations.NotNull;
 import twilightforest.TFRegistries;
-import twilightforest.init.TFRecipes;
 import twilightforest.item.travellers_gear.modifiers.TravellersModifier;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class TravellersGearModifierShapelessRecipe extends TravellersGearModifierRecipe {
+	public static final MapCodec<TravellersGearModifierShapelessRecipe> MAP_CODEC = RecordCodecBuilder.mapCodec(instance ->
+		instance.group(
+			NonNullList.codecOf(Ingredient.CODEC)
+				.fieldOf("ingredients")
+				.forGetter(recipe -> recipe.ingredients),
+			RegistryFixedCodec.create(TFRegistries.Keys.TRAVELLERS_MODIFIERS)
+				.fieldOf("modifier_key")
+				.forGetter(TravellersGearModifierRecipe::getTravellersModifierHolder)
+		).apply(instance, TravellersGearModifierShapelessRecipe::new)
+	);
+
+	public static final StreamCodec<RegistryFriendlyByteBuf, TravellersGearModifierShapelessRecipe> STREAM_CODEC =
+		StreamCodec.composite(
+			ByteBufCodecs.collection(NonNullList::createWithCapacity, Ingredient.CONTENTS_STREAM_CODEC),
+			recipe -> recipe.ingredients,
+
+			ByteBufCodecs.holderRegistry(TFRegistries.Keys.TRAVELLERS_MODIFIERS),
+			TravellersGearModifierRecipe::getTravellersModifierHolder,
+
+			TravellersGearModifierShapelessRecipe::new
+		);
+
+	public static final RecipeSerializer<TravellersGearModifierShapelessRecipe> SERIALIZER = new RecipeSerializer<>(MAP_CODEC, STREAM_CODEC);
+
 	protected final NonNullList<Ingredient> ingredients;
 
-	public TravellersGearModifierShapelessRecipe(NonNullList<Ingredient> ingredients, ResourceKey<TravellersModifier> travellersModifier) {
-		super(travellersModifier);
+	public TravellersGearModifierShapelessRecipe(NonNullList<Ingredient> ingredients, Holder<TravellersModifier> travellersModifierHolder) {
+		super(travellersModifierHolder);
 		this.ingredients = ingredients;
 	}
 
 	@Override
-	public boolean matches(@NotNull CraftingInput input, @NotNull Level level) {
+	public boolean matches(CraftingInput input, Level level) {
 		if (!super.matches(input, level))
 			return false;
 		if (input.ingredientCount() != this.ingredients.size())
@@ -58,19 +85,6 @@ public class TravellersGearModifierShapelessRecipe extends TravellersGearModifie
 
 	@Override
 	public RecipeSerializer<? extends CustomRecipe> getSerializer() {
-		return TFRecipes.MODIFIER_SHAPELESS_RECIPE_SERIALIZER.get();
-	}
-
-	public static class Serializer extends AbstractModifierRecipeSerializer<TravellersGearModifierShapelessRecipe> {
-		public Serializer() {
-			super(RecordCodecBuilder.mapCodec(instance -> instance.group(
-				NonNullList.codecOf(Ingredient.CODEC)
-					.fieldOf("ingredients")
-					.forGetter(recipe -> recipe.ingredients),
-				ResourceKey.codec(TFRegistries.Keys.TRAVELLERS_MODIFIERS)
-					.fieldOf("modifier_key")
-					.forGetter(recipe -> recipe.travellersModifierKey)
-			).apply(instance, TravellersGearModifierShapelessRecipe::new)));
-		}
+		return SERIALIZER;
 	}
 }

--- a/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierShapelessRecipe.java
+++ b/src/main/java/twilightforest/item/recipe/travellers/TravellersGearModifierShapelessRecipe.java
@@ -11,6 +11,7 @@ import net.minecraft.resources.RegistryFixedCodec;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.util.RecipeMatcher;
 import twilightforest.TFRegistries;
 import twilightforest.item.travellers_gear.modifiers.TravellersModifier;
 
@@ -60,7 +61,7 @@ public class TravellersGearModifierShapelessRecipe extends TravellersGearModifie
 			if (!item.isEmpty())
 				nonEmptyItems.add(item);
 		}
-		return net.neoforged.neoforge.common.util.RecipeMatcher.findMatches(nonEmptyItems, this.ingredients) != null;
+		return RecipeMatcher.findMatches(nonEmptyItems, this.ingredients) != null;
 	}
 
 	@Override

--- a/src/main/java/twilightforest/item/travellers_gear/modifiers/TransferableComponentModifier.java
+++ b/src/main/java/twilightforest/item/travellers_gear/modifiers/TransferableComponentModifier.java
@@ -10,10 +10,9 @@ import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.util.Unit;
 import net.minecraft.world.entity.EquipmentSlotGroup;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.CraftingInput;
 import twilightforest.TwilightForestMod;
 
-import java.util.Arrays;
 import java.util.List;
 
 @SuppressWarnings("unchecked")
@@ -69,24 +68,23 @@ public record TransferableComponentModifier(
 	}
 
 	@Override
-	public boolean transfer(ItemStack output, List<Ingredient> input) {
-		List<ItemStack[]> dataComponentProviders = findDataComponentProviders(input);
+	public boolean transfer(ItemStack output, CraftingInput input) {
+		List<ItemStack> dataComponentProviders = findDataComponentProviders(input);
 		if (dataComponentProviders.isEmpty())
 			return false;
 		if (dataComponentProviders.size() > 1) {
 			TwilightForestMod.LOGGER.error(String.format("A recipe with more than 2 dataComponentProviders was matched: %s. Please report to https://github.com/TeamTwilight/twilightforest/issues", input));
 			return false;
 		}
-		ItemStack dataComponentProvider = dataComponentProviders.getFirst()[0];
+		ItemStack dataComponentProvider = dataComponentProviders.getFirst();
 		output.set(this.markerComponent, Unit.INSTANCE);
 		output.set((DataComponentType<Object>) this.transferableComponent.type(), dataComponentProvider.get(transferableComponent.type()));
 		return true;
 	}
 
-	public List<ItemStack[]> findDataComponentProviders(List<Ingredient> input) {
-		return input.stream().map(Ingredient::getItems)
-			.filter(itemStacks -> Arrays.stream(itemStacks)
-				.anyMatch(itemStack -> itemStack.has(transferableComponent.type())))
+	public List<ItemStack> findDataComponentProviders(CraftingInput input) {
+		return input.items().stream()
+			.filter(stack -> stack.has(transferableComponent.type()))
 			.toList();
 	}
 

--- a/src/main/java/twilightforest/item/travellers_gear/modifiers/TransferableTravellersModifier.java
+++ b/src/main/java/twilightforest/item/travellers_gear/modifiers/TransferableTravellersModifier.java
@@ -1,10 +1,8 @@
 package twilightforest.item.travellers_gear.modifiers;
 
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
-
-import java.util.List;
+import net.minecraft.world.item.crafting.CraftingInput;
 
 public interface TransferableTravellersModifier extends InsertableTravellersModifier {
-	boolean transfer(ItemStack stack, List<Ingredient> input);
+	boolean transfer(ItemStack stack, CraftingInput input);
 }

--- a/src/main/java/twilightforest/item/travellers_gear/modifiers/TravellersModifier.java
+++ b/src/main/java/twilightforest/item/travellers_gear/modifiers/TravellersModifier.java
@@ -3,8 +3,8 @@ package twilightforest.item.travellers_gear.modifiers;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.MapCodec;
+import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.EquipmentSlotGroup;
 import net.minecraft.world.item.ItemStack;
@@ -35,8 +35,8 @@ public interface TravellersModifier {
 		return "travellers_gear.modifier";
 	}
 
-	default boolean isActive(ItemStack stack, ResourceKey<TravellersModifier> modifier, boolean spectator) {
-		return this.hasModifier(stack) && !spectator && (!TravellersArmorItem.isTravellersArmorAndBroken(stack) || TravellersModifiersManager.ALWAYS_ACTIVE.contains(modifier));
+	default boolean isActive(ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder, boolean spectator) {
+		return this.hasModifier(stack) && !spectator && (!TravellersArmorItem.isTravellersArmorAndBroken(stack) || TravellersModifiersManager.ALWAYS_ACTIVE.contains(modifierHolder.getKey()));
 	}
 
 	static DataResult<EquipmentSlotGroup> validateEquipment(EquipmentSlotGroup group) {

--- a/src/main/java/twilightforest/item/travellers_gear/modifiers/TravellersModifier.java
+++ b/src/main/java/twilightforest/item/travellers_gear/modifiers/TravellersModifier.java
@@ -35,8 +35,8 @@ public interface TravellersModifier {
 		return "travellers_gear.modifier";
 	}
 
-	default boolean isActive(ItemStack stack, Holder.Reference<TravellersModifier> modifierHolder, boolean spectator) {
-		return this.hasModifier(stack) && !spectator && (!TravellersArmorItem.isTravellersArmorAndBroken(stack) || TravellersModifiersManager.ALWAYS_ACTIVE.contains(modifierHolder.getKey()));
+	default boolean isActive(ItemStack stack, Holder<TravellersModifier> modifierHolder, boolean spectator) {
+		return this.hasModifier(stack) && !spectator && (!TravellersArmorItem.isTravellersArmorAndBroken(stack) || TravellersModifiersManager.ALWAYS_ACTIVE.contains(modifierHolder.unwrapKey().orElseThrow()));
 	}
 
 	static DataResult<EquipmentSlotGroup> validateEquipment(EquipmentSlotGroup group) {

--- a/src/main/java/twilightforest/item/travellers_gear/modifiers/TravellersModifier.java
+++ b/src/main/java/twilightforest/item/travellers_gear/modifiers/TravellersModifier.java
@@ -36,7 +36,7 @@ public interface TravellersModifier {
 	}
 
 	default boolean isActive(ItemStack stack, Holder<TravellersModifier> modifierHolder, boolean spectator) {
-		return this.hasModifier(stack) && !spectator && (!TravellersArmorItem.isTravellersArmorAndBroken(stack) || TravellersModifiersManager.ALWAYS_ACTIVE.contains(modifierHolder.unwrapKey().orElseThrow()));
+		return this.hasModifier(stack) && !spectator && (!TravellersArmorItem.isTravellersArmorAndBroken(stack) || TravellersModifiersManager.ALWAYS_ACTIVE.contains(TravellersModifiersManager.getKeyOrThrow(modifierHolder)));
 	}
 
 	static DataResult<EquipmentSlotGroup> validateEquipment(EquipmentSlotGroup group) {


### PR DESCRIPTION
Note - This is the same PR as #2664, I just had to recreate it since I renamed my branch. Also marked as ready for review since it might be helpful to leave comments.

Summary
========

- Serializer classes removed in favor of codecs
- CraftingBookCategory moved out of constructor to match super
- List<Ingredient> and List<Ingredient[]> swapped for CraftingInput where possible
- ResourceKey<TravellersModifier> switched to Holder<TravellersModifier> where applicable
- Modifier caching system removed since the holder already stores a reference to the backing registry value