### PR TITLE
Fix ParticlePacket call sites

### DIFF
--- a/src/main/java/twilightforest/block/AbstractTrophyBlock.java
+++ b/src/main/java/twilightforest/block/AbstractTrophyBlock.java
@@ -155,7 +155,7 @@ public abstract class AbstractTrophyBlock extends BaseEntityBlock {
 			switch (this.variant) {
 				case NAGA:
 					for (int daze = 0; daze < 10; daze++) {
-						particlePacket.queueParticle(ParticleTypes.CRIT, false,
+						particlePacket.queueParticle(ParticleTypes.CRIT, false,false,
 							((double) pos.getX() + rand.nextFloat() * 0.5D * 2.0D),
 							(double) pos.getY() + 0.25D,
 							((double) pos.getZ() + rand.nextFloat() * 0.5D * 2.0D),
@@ -164,7 +164,7 @@ public abstract class AbstractTrophyBlock extends BaseEntityBlock {
 					break;
 				case LICH:
 					for (int a = 0; a < 5; a++) {
-						particlePacket.queueParticle(TFParticleType.ANGRY_LICH.get(), false,
+						particlePacket.queueParticle(TFParticleType.ANGRY_LICH.get(), false, false,
 							(double) pos.getX() + rand.nextFloat() * 0.5D * 2.0F + rand.nextGaussian() * 0.02D,
 							(double) pos.getY() + 0.5D + rand.nextFloat() * 0.25 + rand.nextGaussian() * 0.02D,
 							(double) pos.getZ() + rand.nextFloat() * 0.5D * 2.0F + rand.nextGaussian() * 0.02D,
@@ -174,7 +174,7 @@ public abstract class AbstractTrophyBlock extends BaseEntityBlock {
 				case MINOSHROOM:
 					ParticleOptions minoshroomParticle = new BlockParticleOption(ParticleTypes.BLOCK, level.getBlockState(pos.below()));
 					for (int g = 0; g < 10; g++) {
-						particlePacket.queueParticle(minoshroomParticle, false,
+						particlePacket.queueParticle(minoshroomParticle, false, false,
 							(double) pos.getX() + rand.nextFloat() * 10F - 5F,
 							(double) pos.getY() + 0.1F + rand.nextFloat() * 0.3F,
 							(double) pos.getZ() + rand.nextFloat() * 10F - 5F,
@@ -184,7 +184,7 @@ public abstract class AbstractTrophyBlock extends BaseEntityBlock {
 				case KNIGHT_PHANTOM:
 					ParticleOptions knightPhantomParticle = new ItemParticleOption(ParticleTypes.ITEM, TFItems.KNIGHTMETAL_SWORD.get());
 					for (int brek = 0; brek < 10; brek++) {
-						particlePacket.queueParticle(knightPhantomParticle, false,
+						particlePacket.queueParticle(knightPhantomParticle, false, false,
 							pos.getX() + 0.5D + (rand.nextFloat() - 0.5D),
 							pos.getY() + rand.nextFloat() + 0.5D + 0.25D * rand.nextGaussian(),
 							pos.getZ() + 0.5D + (rand.nextFloat() - 0.5D),
@@ -193,7 +193,7 @@ public abstract class AbstractTrophyBlock extends BaseEntityBlock {
 					break;
 				case UR_GHAST:
 					for (int red = 0; red < 10; red++) {
-						particlePacket.queueParticle(DustParticleOptions.REDSTONE, false,
+						particlePacket.queueParticle(DustParticleOptions.REDSTONE, false, false,
 							(double) pos.getX() + (rand.nextDouble() * 1),
 							(double) pos.getY() + rand.nextDouble() * 0.5 + 0.5,
 							(double) pos.getZ() + (rand.nextDouble() * 1),
@@ -202,7 +202,7 @@ public abstract class AbstractTrophyBlock extends BaseEntityBlock {
 					break;
 				case ALPHA_YETI:
 					for (int sweat = 0; sweat < 10; sweat++) {
-						particlePacket.queueParticle(ParticleTypes.SPLASH, false,
+						particlePacket.queueParticle(ParticleTypes.SPLASH, false, false,
 							(double) pos.getX() + (rand.nextDouble() * 1),
 							(double) pos.getY() + rand.nextDouble() * 0.5 + 0.5,
 							(double) pos.getZ() + (rand.nextDouble() * 1),
@@ -211,7 +211,7 @@ public abstract class AbstractTrophyBlock extends BaseEntityBlock {
 					break;
 				case SNOW_QUEEN:
 					for (int b = 0; b < 20; b++) {
-						particlePacket.queueParticle(TFParticleType.SNOW_WARNING.get(), false,
+						particlePacket.queueParticle(TFParticleType.SNOW_WARNING.get(), false, false,
 							(double) pos.getX() - 1 + (rand.nextDouble() * 3.25D),
 							(double) pos.getY() + 5 + rand.nextGaussian(),
 							(double) pos.getZ() - 1 + (rand.nextDouble() * 3.25D),
@@ -220,7 +220,7 @@ public abstract class AbstractTrophyBlock extends BaseEntityBlock {
 					break;
 				case QUEST_RAM:
 					for (int p = 0; p < 10; p++) {
-						particlePacket.queueParticle(ColorParticleOption.create(TFParticleType.MAGIC_EFFECT.get(), rand.nextFloat(), rand.nextFloat(), rand.nextFloat()), false,
+						particlePacket.queueParticle(ColorParticleOption.create(TFParticleType.MAGIC_EFFECT.get(), rand.nextFloat(), rand.nextFloat(), rand.nextFloat()), false, false,
 							(double) pos.getX() + 0.5 + (rand.nextDouble() - 0.5),
 							(double) pos.getY() + (rand.nextDouble() - 0.5),
 							(double) pos.getZ() + 0.5 + (rand.nextDouble() - 0.5),

--- a/src/main/java/twilightforest/block/CastleDoorBlock.java
+++ b/src/main/java/twilightforest/block/CastleDoorBlock.java
@@ -151,7 +151,7 @@ public class CastleDoorBlock extends Block {
 			for (int dx = 0; dx < 4; ++dx) {
 				for (int dy = 0; dy < 4; ++dy) {
 					for (int dz = 0; dz < 4; ++dz) {
-						particlePacket.queueParticle(TFParticleType.ANNIHILATE.get(), false,
+						particlePacket.queueParticle(TFParticleType.ANNIHILATE.get(), false, false,
 							pos.getX() + (dx + 0.5D) / 4,
 							pos.getY() + (dy + 0.5D) / 4,
 							pos.getZ() + (dz + 0.5D) / 4,

--- a/src/main/java/twilightforest/block/ChiseledCanopyShelfBlock.java
+++ b/src/main/java/twilightforest/block/ChiseledCanopyShelfBlock.java
@@ -89,7 +89,7 @@ public class ChiseledCanopyShelfBlock extends ChiseledBookShelfBlock {
 			level.playSound(null, pos, TFSounds.DEATH_TOME_DEATH.get(), SoundSource.BLOCKS, 1.0F, 1.0F);
 			ParticlePacket particlePacket = new ParticlePacket();
 			for (int i = 0; i < 20; ++i) {
-				particlePacket.queueParticle(ParticleTypes.POOF, false,
+				particlePacket.queueParticle(ParticleTypes.POOF, false, false,
 					(double) pos.getX() + 0.5D + level.getRandom().nextGaussian() * 0.02D * level.getRandom().nextGaussian(),
 					(double) pos.getY() + level.getRandom().nextGaussian() * 0.02D * level.getRandom().nextGaussian(),
 					(double) pos.getZ() + 0.5D + level.getRandom().nextGaussian() * 0.02D * level.getRandom().nextGaussian(),

--- a/src/main/java/twilightforest/block/CloudBlock.java
+++ b/src/main/java/twilightforest/block/CloudBlock.java
@@ -148,7 +148,7 @@ public class CloudBlock extends Block {
 			double xSpeed = xSpd * 0.0035D * maxI;
 			double zSpeed = zSpd * 0.0035D * maxI;
 
-			particlePacket.queueParticle(TFParticleType.CLOUD_PUFF.get(), false, x, y, z, xSpeed, ySpeed, zSpeed);
+			particlePacket.queueParticle(TFParticleType.CLOUD_PUFF.get(), false, false, x, y, z, xSpeed, ySpeed, zSpeed);
 		}
 
 		PacketDistributor.sendToPlayersTrackingChunk(level, ChunkPos.containing(pos), particlePacket);

--- a/src/main/java/twilightforest/block/SortLogCoreBlock.java
+++ b/src/main/java/twilightforest/block/SortLogCoreBlock.java
@@ -129,7 +129,7 @@ public class SortLogCoreBlock extends SpecialMagicLogBlock {
 								double x = diff.x - 0.25D + rand.nextDouble() * 0.5D;
 								double y = diff.y - 1.75D + rand.nextDouble() * 0.5D;
 								double z = diff.z - 0.25D + rand.nextDouble() * 0.5D;
-								particlePacket.queueParticle(TFParticleType.SORTING_PARTICLE.get(), false, xyz, new Vec3(x, y, z).scale(1D / diff.length()));
+								particlePacket.queueParticle(TFParticleType.SORTING_PARTICLE.get(), false, false, xyz, new Vec3(x, y, z).scale(1D / diff.length()));
 								PacketDistributor.sendToPlayersNear(level, null, xyz.x(), xyz.y(), xyz.z(), 64.0D, particlePacket);
 								break;
 							}

--- a/src/main/java/twilightforest/block/TimeLogCoreBlock.java
+++ b/src/main/java/twilightforest/block/TimeLogCoreBlock.java
@@ -66,7 +66,7 @@ public class TimeLogCoreBlock extends SpecialMagicLogBlock {
 					Vec3 xyz = Vec3.atCenterOf(dPos);
 					ParticlePacket particlePacket = new ParticlePacket();
 					double yOffset = state.getOcclusionShape().max(Direction.Axis.Y);
-					particlePacket.queueParticle(TFParticleType.LOG_CORE_PARTICLE.get(), false, xyz.add(0.0, yOffset - 0.5, 0.0), new Vec3(0.953, 0.698, 0.0));
+					particlePacket.queueParticle(TFParticleType.LOG_CORE_PARTICLE.get(), false, false, xyz.add(0.0, yOffset - 0.5, 0.0), new Vec3(0.953, 0.698, 0.0));
 					PacketDistributor.sendToPlayersNear(level, null, xyz.x(), xyz.y(), xyz.z(), 64.0D, particlePacket);
 				}
 			}

--- a/src/main/java/twilightforest/block/TransLogCoreBlock.java
+++ b/src/main/java/twilightforest/block/TransLogCoreBlock.java
@@ -77,7 +77,7 @@ public class TransLogCoreBlock extends SpecialMagicLogBlock {
 			for (int j = 0; j < 9; j++) {
 				float angle = rand.nextFloat() * 360.0F;
 				Vec3 offset = new Vec3(Math.cos(angle), 0.0D, Math.sin(angle)).scale(2.0D);
-				particlePacket.queueParticle(TFParticleType.TRANSFORMATION_PARTICLE.get(), false, xyz.add(offset), Vec3.ZERO.subtract(offset));
+				particlePacket.queueParticle(TFParticleType.TRANSFORMATION_PARTICLE.get(), false, false, xyz.add(offset), Vec3.ZERO.subtract(offset));
 			}
 			PacketDistributor.sendToPlayersNear(level, null, xyz.x(), xyz.y(), xyz.z(), 64.0D, particlePacket);
 			break;

--- a/src/main/java/twilightforest/components/entity/FortificationShieldAttachment.java
+++ b/src/main/java/twilightforest/components/entity/FortificationShieldAttachment.java
@@ -109,7 +109,7 @@ public class FortificationShieldAttachment {
 				double x = sizeRange * offset.z * horizontal;
 				double y = sizeRange * (entity.getRandom().nextDouble() - 0.5D);
 				double z = sizeRange * offset.x * -horizontal;
-				particlePacket.queueParticle(TFParticleType.SHIELD_BREAK.get(), false, pos.x + x, pos.y + y, pos.z + z, x * 0.5D, y * 0.5D, z * 0.5D);
+				particlePacket.queueParticle(TFParticleType.SHIELD_BREAK.get(), false, false, pos.x + x, pos.y + y, pos.z + z, x * 0.5D, y * 0.5D, z * 0.5D);
 			}
 		} else {
 			pos = entity.position().add(0.0D, entity.getBbHeight() * 0.65D, 0.0D);

--- a/src/main/java/twilightforest/entity/boss/IBossLootBuffer.java
+++ b/src/main/java/twilightforest/entity/boss/IBossLootBuffer.java
@@ -108,7 +108,7 @@ public interface IBossLootBuffer {
 			double x = (boss.getRandom().nextDouble() - 0.5D) * 0.075D * i;
 			double y = (boss.getRandom().nextDouble() - 0.5D) * 0.075D * i;
 			double z = (boss.getRandom().nextDouble() - 0.5D) * 0.075D * i;
-			particlePacket.queueParticle(ParticleTypes.POOF, false, vec3.add(x, y, z), Vec3.ZERO);
+			particlePacket.queueParticle(ParticleTypes.POOF, false, false, vec3.add(x, y, z), Vec3.ZERO);
 		}
 		PacketDistributor.sendToPlayersTrackingEntity(boss, particlePacket);
 	}

--- a/src/main/java/twilightforest/entity/boss/Lich.java
+++ b/src/main/java/twilightforest/entity/boss/Lich.java
@@ -474,7 +474,7 @@ public class Lich extends BaseTFBoss {
 						double x = clone.getX((this.random.nextDouble() * this.random.nextDouble() * (this.random.nextBoolean() ? 1.0D : -1.0D)) * 1.5D);
 						double y = clone.getY(this.random.nextDouble() * this.random.nextDouble() * 1.25D);
 						double z = clone.getZ((this.random.nextDouble() * this.random.nextDouble() * (this.random.nextBoolean() ? 1.0D : -1.0D)) * 1.5D);
-						particlePacket.queueParticle(ParticleTypes.SMOKE, false, x, y, z, 0.0D, 0.0D, 0.0D);
+						particlePacket.queueParticle(ParticleTypes.SMOKE, false, false, x, y, z, 0.0D, 0.0D, 0.0D);
 					}
 
 					PacketDistributor.sendToPlayersTrackingEntity(this, particlePacket);
@@ -683,14 +683,14 @@ public class Lich extends BaseTFBoss {
 					double x = this.getX(this.random.nextDouble() * this.random.nextDouble() * (this.random.nextBoolean() ? 1.0D : -1.0D));
 					double y =  this.getY(this.random.nextDouble());
 					double z = this.getZ(this.random.nextDouble() * this.random.nextDouble() * (this.random.nextBoolean() ? 1.0D : -1.0D));
-					particlePacket.queueParticle(options, false, x, y, z, (x - pos.x) * 0.0625D, (y - pos.y) * 0.0625D, (z - pos.z) * 0.0625D);
+					particlePacket.queueParticle(options, false, false, x, y, z, (x - pos.x) * 0.0625D, (y - pos.y) * 0.0625D, (z - pos.z) * 0.0625D);
 				}
 			} else {
 				for(int j = 0; j < (!this.isShadowClone() ? 128 : 64); ++j) {
 					double x = this.getX((this.random.nextDouble() * this.random.nextDouble() * (this.random.nextBoolean() ? 1.0D : -1.0D)) * 2.0D);
 					double y =  this.getY(this.random.nextDouble() * 1.125D);
 					double z = this.getZ((this.random.nextDouble() * this.random.nextDouble() * (this.random.nextBoolean() ? 1.0D : -1.0D)) * 2.0D);
-					particlePacket.queueParticle(ParticleTypes.SMOKE, false, x, y, z, 0.0D, 0.0D, 0.0D);
+					particlePacket.queueParticle(ParticleTypes.SMOKE, false, false, x, y, z, 0.0D, 0.0D, 0.0D);
 				}
 			}
 
@@ -710,7 +710,7 @@ public class Lich extends BaseTFBoss {
 						double tx = source.x() + (target.x() - source.x()) * trailFactor + this.getRandom().nextGaussian() * 0.005D;
 						double ty = source.y() + 0.2D + (target.y() - source.y()) * trailFactor + this.getRandom().nextGaussian() * 0.005D;
 						double tz = source.z() + (target.z() - source.z()) * trailFactor + this.getRandom().nextGaussian() * 0.005D;
-						packet.queueParticle(ColorParticleOption.create(TFParticleType.MAGIC_EFFECT.get(), red, green, blue), false, tx, ty, tz, 0.0D, 0.0D, 0.0D);
+						packet.queueParticle(ColorParticleOption.create(TFParticleType.MAGIC_EFFECT.get(), red, green, blue), false, false, tx, ty, tz, 0.0D, 0.0D, 0.0D);
 					}
 
 					PacketDistributor.sendToPlayersTrackingEntity(this, packet);

--- a/src/main/java/twilightforest/entity/monster/Kobold.java
+++ b/src/main/java/twilightforest/entity/monster/Kobold.java
@@ -163,7 +163,7 @@ public class Kobold extends Monster {
 			ParticlePacket particlePacket = new ParticlePacket();
 			for (int i = 0; i < amount; ++i) {
 				this.getItemParticleVectors((vec31, vec3) ->
-					particlePacket.queueParticle(particleOptions, false,
+					particlePacket.queueParticle(particleOptions, false, false,
 						vec31.x() + vec3.x() * this.random.nextGaussian(),
 						vec31.y() + (vec3.y() + 0.05D) * this.random.nextGaussian(),
 						vec31.z() + vec3.z() * this.random.nextGaussian(),

--- a/src/main/java/twilightforest/entity/monster/UpperGoblinKnight.java
+++ b/src/main/java/twilightforest/entity/monster/UpperGoblinKnight.java
@@ -208,7 +208,7 @@ public class UpperGoblinKnight extends Monster {
 		if (this.level() instanceof ServerLevel) {
 			ParticlePacket particlePacket = new ParticlePacket();
 			for (int i = 0; i < 50; i++) {
-				particlePacket.queueParticle(ParticleTypes.LARGE_SMOKE, false,
+				particlePacket.queueParticle(ParticleTypes.LARGE_SMOKE, false, false,
 					px + (this.getRandom().nextFloat() - this.getRandom().nextFloat()) * 0.25F * this.getRandom().nextGaussian(),
 					py,
 					pz + (this.getRandom().nextFloat() - this.getRandom().nextFloat()) * 0.25F * this.getRandom().nextGaussian(),

--- a/src/main/java/twilightforest/entity/passive/QuestRam.java
+++ b/src/main/java/twilightforest/entity/passive/QuestRam.java
@@ -221,7 +221,7 @@ public class QuestRam extends Animal implements EnforcedHomePoint {
 					ParticlePacket packet = new ParticlePacket();
 
 					for (int i = 0; i < iterations; i++) {
-						packet.queueParticle(ColorParticleOption.create(ParticleTypes.ENTITY_EFFECT, ARGB.red(colorVal), ARGB.green(colorVal), ARGB.blue(colorVal)), false,
+						packet.queueParticle(ColorParticleOption.create(ParticleTypes.ENTITY_EFFECT, ARGB.red(colorVal), ARGB.green(colorVal), ARGB.blue(colorVal)), false, false,
 							this.getX() + (this.getRandom().nextDouble() - 0.5D) * this.getBbWidth() * 1.5D,
 							this.getY() + this.getRandom().nextDouble() * this.getBbHeight() * 1.5D,
 							this.getZ() + (this.getRandom().nextDouble() - 0.5D) * this.getBbWidth() * 1.5D,

--- a/src/main/java/twilightforest/entity/projectile/CubeOfAnnihilation.java
+++ b/src/main/java/twilightforest/entity/projectile/CubeOfAnnihilation.java
@@ -132,7 +132,7 @@ public class CubeOfAnnihilation extends ThrowableProjectile {
 			for (int dx = 0; dx < 3; dx++) {
 				for (int dy = 0; dy < 3; dy++) {
 					for (int dz = 0; dz < 3; dz++) {
-						particlePacket.queueParticle(TFParticleType.ANNIHILATE.get(), false,
+						particlePacket.queueParticle(TFParticleType.ANNIHILATE.get(), false, false,
 							pos.getX() + (dx + 0.5D) / 4,
 							pos.getY() + (dy + 0.5D) / 4,
 							pos.getZ() + (dz + 0.5D) / 4,

--- a/src/main/java/twilightforest/events/TravellersGearEvents.java
+++ b/src/main/java/twilightforest/events/TravellersGearEvents.java
@@ -137,7 +137,7 @@ public class TravellersGearEvents {
 				(level.getRandom().nextDouble() - 0.5)
 			);
 			ParticleOptions type = TFParticleType.PERFECT_DODGE.get();
-			particlePacket.queueParticle(type, false, hitPosition, particleVelocity);
+			particlePacket.queueParticle(type, false, false, hitPosition, particleVelocity);
 		}
 		PacketDistributor.sendToPlayersTrackingEntityAndSelf(livingEntity, particlePacket);
 	}

--- a/src/main/java/twilightforest/item/GlassSwordItem.java
+++ b/src/main/java/twilightforest/item/GlassSwordItem.java
@@ -35,7 +35,7 @@ public class GlassSwordItem extends Item {
 		if (target.level() instanceof ServerLevel) {
 			ParticlePacket particlePacket = new ParticlePacket();
 			for (int i = 0; i < 20; i++) {
-				particlePacket.queueParticle(GLASS_PARTICLE, false,
+				particlePacket.queueParticle(GLASS_PARTICLE, false, false,
 				target.getX() + target.getRandom().nextFloat() * target.getBbWidth() * 2.0F - target.getBbWidth(),
 				target.getY() + target.getRandom().nextFloat() * target.getBbHeight(),
 				target.getZ() + target.getRandom().nextFloat() * target.getBbWidth() * 2.0F - target.getBbWidth(),

--- a/src/main/java/twilightforest/item/IceSwordItem.java
+++ b/src/main/java/twilightforest/item/IceSwordItem.java
@@ -19,7 +19,7 @@ public class IceSwordItem extends Item {
 		ApplyFrostedEffect.doChillAuraEffect(target, 200, 2, true);
 		ParticlePacket particlePacket = new ParticlePacket();
 		for (int i = 0; i < 20; i++) {
-			particlePacket.queueParticle(TFParticleType.SNOW.get(), false,
+			particlePacket.queueParticle(TFParticleType.SNOW.get(), false, false,
 				target.getX() + (target.getRandom().nextGaussian() * target.getBbWidth() * 0.5),
 				target.getY() + target.getBbHeight() * 0.5F + (target.getRandom().nextGaussian() * target.getBbHeight() * 0.5),
 				target.getZ() + (target.getRandom().nextGaussian() * target.getBbWidth() * 0.5),

--- a/src/main/java/twilightforest/item/LifedrainScepterItem.java
+++ b/src/main/java/twilightforest/item/LifedrainScepterItem.java
@@ -75,7 +75,7 @@ public class LifedrainScepterItem extends ScepterItem {
 			double y = level.getRandom().nextFloat() * target.getBbHeight() - gaussY * gaussFactor + (level.getRandom().nextGaussian() * gaussY);
 			double z = level.getRandom().nextFloat() * target.getBbWidth() * 1.5F - target.getBbWidth() - gaussZ * gaussFactor + (level.getRandom().nextGaussian() * gaussZ);
 
-			particlePacket.queueParticle(options, false, target.getX() + x, target.getY() + y, target.getZ() + z, x * speed, y * speed, z * speed);
+			particlePacket.queueParticle(options, false, false, target.getX() + x, target.getY() + y, target.getZ() + z, x * speed, y * speed, z * speed);
 		}
 
 		PacketDistributor.sendToPlayersTrackingEntity(target, particlePacket);

--- a/src/main/java/twilightforest/item/OreMagnetItem.java
+++ b/src/main/java/twilightforest/item/OreMagnetItem.java
@@ -158,7 +158,7 @@ public class OreMagnetItem extends Item {
 								ParticlePacket particlePacket = new ParticlePacket();
 								for (int i = 0; i < 16; i++) {
 									Vec3 offset = new Vec3((level.getRandom().nextDouble() - 0.5D) * 1.25D, (level.getRandom().nextDouble() - 0.5D) * 1.25D, (level.getRandom().nextDouble() - 0.5D) * 1.25D);
-									particlePacket.queueParticle(TFParticleType.LOG_CORE_PARTICLE.get(), false, xyz.add(offset), new Vec3(0.8, 0.9, 0.2));
+									particlePacket.queueParticle(TFParticleType.LOG_CORE_PARTICLE.get(), false, false, xyz.add(offset), new Vec3(0.8, 0.9, 0.2));
 								}
 								PacketDistributor.sendToPlayer(serverplayer, particlePacket);
 							}

--- a/src/main/java/twilightforest/item/PeacockFanItem.java
+++ b/src/main/java/twilightforest/item/PeacockFanItem.java
@@ -57,7 +57,7 @@ public class PeacockFanItem extends Item {
 						ParticlePacket packet = new ParticlePacket();
 
 						for (int i = 0; i < 30; i++) {
-							packet.queueParticle(ParticleTypes.CLOUD, true, fanBox.minX + level.getRandom().nextFloat() * (fanBox.maxX - fanBox.minX),
+							packet.queueParticle(ParticleTypes.CLOUD, false, true, fanBox.minX + level.getRandom().nextFloat() * (fanBox.maxX - fanBox.minX),
 								fanBox.minY + level.getRandom().nextFloat() * (fanBox.maxY - fanBox.minY),
 								fanBox.minZ + level.getRandom().nextFloat() * (fanBox.maxZ - fanBox.minZ),
 								lookVec.x(), lookVec.y(), lookVec.z());

--- a/src/main/java/twilightforest/item/travellers_gear/TravellersGearLogic.java
+++ b/src/main/java/twilightforest/item/travellers_gear/TravellersGearLogic.java
@@ -79,7 +79,7 @@ public class TravellersGearLogic {
 			if (level.isClientSide()) {
 				level.addParticle(ParticleTypes.SPLASH, particlePos.x(), particlePos.y(), particlePos.z(), particleVelocity.x(), particleVelocity.y(), particleVelocity.z());
 			} else {
-				particlePacket.queueParticle(ParticleTypes.SPLASH, false, particlePos, particleVelocity);
+				particlePacket.queueParticle(ParticleTypes.SPLASH, false, false, particlePos, particleVelocity);
 			}
 		}
 
@@ -268,7 +268,7 @@ public class TravellersGearLogic {
 				);
 				ParticleOptions type = TFParticleType.DOUBLE_JUMP.get();
 				Vec3 wingsPosition = player.position().add(Math.sin(Math.toRadians(player.yBodyRot)) / 3, 1.2, -Math.cos(Math.toRadians(player.yBodyRot)) / 3);
-				particlePacket.queueParticle(type, false, wingsPosition, particleVelocity.multiply(0.25, -0.5, 0.25).add(deltaMovement));
+				particlePacket.queueParticle(type, false, false, wingsPosition, particleVelocity.multiply(0.25, -0.5, 0.25).add(deltaMovement));
 			}
 			PacketDistributor.sendToPlayersTrackingEntityAndSelf(player, particlePacket);
 			TravellersWingsAttachment attachment = player.getData(TFDataAttachments.TRAVELLERS_WINGS);


### PR DESCRIPTION
In my network PR, I added a new boolean field to *QueuedParticle* to reflect the addition of the flag *overrideLimiter* to *Level#addParticle(...)*. The second field of our record is now *overrideLimiter* and the previous field, *alwaysShow*, has been shifted one place right. To reflect this change at call sites, it is necessary to add a new false argument in the second slot of the arguments list and shift all other arguments to the right. I believe that false reflects our intended behavior, but do correct me if I am wrong. On the diffs where both arguments are false, GitHub does not display the change in the correct location. In *PeacockFanItem*, where *alwaysShow* is true, GitHub does show the change in the correct location.