### PR TITLE
Bump Foojay Resolver to 1.0.0 to fix Gradle incompatibility

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,7 @@ pluginManagement {
 }
 
 plugins {
-	id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+	id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 include ':tf-asm'


### PR DESCRIPTION
Upon cloning the project on a new Linux install and installing Idea 26.2, I found that I was unable to run the IDE sync and import the project. I went down a bit of a rabbit hole in the logs until I found that the root cause was Foojay Resolver 0.8.0 being incompatible with Gradle 9.0+ due to a removed variable. I am assuming that this has not been caught so far since it never had to actually resolve anything.