### PR TITLE
Error fixes and updates to Restriction

### DIFF
--- a/src/main/java/twilightforest/util/Restriction.java
+++ b/src/main/java/twilightforest/util/Restriction.java
@@ -2,21 +2,20 @@ package twilightforest.util;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.structure.Structure;
+import org.jspecify.annotations.Nullable;
 import twilightforest.TFRegistries;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,20 +51,9 @@ public record Restriction(@Nullable ResourceKey<Structure> hintStructureKey, Res
 			return Optional.empty();
 
 		Optional<Registry<Restriction>> restrictionsRegistry = access.lookup(TFRegistries.Keys.RESTRICTIONS);
-		if (restrictionsRegistry.isEmpty())
-			return Optional.empty();
-
-		Restriction restrictions = restrictionsRegistry.get().get(biomeLocation).map(Holder.Reference::value).orElse(null);
-		if (restrictions == null || PlayerHelper.doesPlayerHaveRequiredAdvancements(player, restrictions.advancements())) {
-			return Optional.empty();
-		}
-
-		return Optional.of(restrictions);
-	}
-
-	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-	private static Restriction create(Optional<ResourceKey<Structure>> hintStructureKey, ResourceKey<Enforcement> enforcer, float multiplier, Optional<ItemStackTemplate> lockedBiomeToast, List<Identifier> advancements) {
-		return new Restriction(hintStructureKey.orElse(null), enforcer, multiplier, lockedBiomeToast.orElse(null), advancements);
+		return restrictionsRegistry.flatMap(restrictions -> restrictions
+			.getOptional(biomeLocation)
+			.filter(r -> !PlayerHelper.doesPlayerHaveRequiredAdvancements(player, r.advancements())));
 	}
 
 	public static boolean isBiomeSafeFor(Biome biome, Entity entity) {

--- a/src/main/java/twilightforest/util/Restriction.java
+++ b/src/main/java/twilightforest/util/Restriction.java
@@ -2,7 +2,6 @@ package twilightforest.util;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
@@ -27,7 +26,6 @@ import java.util.Optional;
  * @param advancements     List of advancements that are required to make a biome no longer restricted
  */
 public record Restriction(@Nullable ResourceKey<Structure> hintStructureKey, ResourceKey<Enforcement> enforcement, float multiplier, @Nullable ItemStackTemplate lockedBiomeToast, List<Identifier> advancements) {
-
 	public static final Codec<Restriction> CODEC = RecordCodecBuilder.create((recordCodecBuilder) -> recordCodecBuilder.group(
 		ResourceKey.codec(Registries.STRUCTURE).optionalFieldOf("structure_key").forGetter((restriction) -> Optional.ofNullable(restriction.hintStructureKey())),
 		ResourceKey.codec(TFRegistries.Keys.ENFORCEMENT).fieldOf("enforcement").forGetter(Restriction::enforcement),
@@ -42,18 +40,17 @@ public record Restriction(@Nullable ResourceKey<Structure> hintStructureKey, Res
 	}
 
 	public static Optional<Restriction> getRestrictionForBiome(Biome biome, Entity entity) {
-		if (!(entity instanceof Player player))
-			return Optional.empty();
-
-		RegistryAccess access = entity.level().registryAccess();
-		Identifier biomeLocation = access.lookupOrThrow(Registries.BIOME).getKey(biome);
-		if (biomeLocation == null)
-			return Optional.empty();
-
-		Optional<Registry<Restriction>> restrictionsRegistry = access.lookup(TFRegistries.Keys.RESTRICTIONS);
-		return restrictionsRegistry.flatMap(restrictions -> restrictions
-			.getOptional(biomeLocation)
-			.filter(r -> !PlayerHelper.doesPlayerHaveRequiredAdvancements(player, r.advancements())));
+		if (entity instanceof Player player) {
+			RegistryAccess access = entity.level().registryAccess();
+			Identifier biomeLocation = access.lookupOrThrow(Registries.BIOME).getKey(biome);
+			if (biomeLocation != null) {
+				Restriction restrictions = access.lookupOrThrow(TFRegistries.Keys.RESTRICTIONS).getValue(biomeLocation);
+				if (restrictions != null && !PlayerHelper.doesPlayerHaveRequiredAdvancements(player, restrictions.advancements())) {
+					return Optional.of(restrictions);
+				}
+			}
+		}
+		return Optional.empty();
 	}
 
 	public static boolean isBiomeSafeFor(Biome biome, Entity entity) {


### PR DESCRIPTION
Deletes a duplicated method that causes the record to not compile, replaces current *Nullable* annotation with JSpecify equivalent, and replaces the current *getRestrictionForBiome(...)* method with an updated version of Giz's compact alternative from b1f2be2 on the 1.21.x branch.