### PR TITLE
Add Piglin Skull Candle to Candle dispenser behavior

### DIFF
--- a/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
+++ b/src/main/java/twilightforest/dispenser/CandleDispenseBehavior.java
@@ -98,6 +98,10 @@ public class CandleDispenseBehavior extends OptionalDispenseItemBehavior {
 					if (wall) makeWallSkull(level, pos, TFBlocks.CREEPER_WALL_SKULL_CANDLE.get(), candle);
 					else makeFloorSkull(level, pos, TFBlocks.CREEPER_SKULL_CANDLE.get(), candle);
 				}
+				case PIGLIN -> {
+					if (wall) makeWallSkull(level, pos, TFBlocks.PIGLIN_WALL_SKULL_CANDLE.get(), candle);
+					else makeFloorSkull(level, pos, TFBlocks.PIGLIN_SKULL_CANDLE.get(), candle);
+				}
 				default -> {
 					return false;
 				}


### PR DESCRIPTION
I guess when the Piglin Skull Candle was added, adding it to the dispenser behavior was missed? Tested and functions properly so doesn't seem like there'd be any other reason for it to not work? Should also be fine for 26.1 as well as long as it already works for the rest there, since the switch statement is the same code.