### PR TITLE
Fix race condition in TFGameRules registration causing NPE on portal use - TF 1.21.1

### DIFF
--- a/src/main/java/twilightforest/init/TFGameRules.java
+++ b/src/main/java/twilightforest/init/TFGameRules.java
@@ -40,6 +40,6 @@ public class TFGameRules {
 
 	public static void register() {
 		// Get main thread and use it to register our game rules early
-		GAME_RULES.forEach(gameRule -> Util.backgroundExecutor().execute(gameRule::get));
+		GAME_RULES.forEach(Supplier::get);
 	}
 }


### PR DESCRIPTION
## Problem

`TFGameRules.register()` registers the custom game rules (including
`playersTfPortalDefaultDelay` and `playersTfPortalCreativeDelay`) by
calling `.get()` on each memoized `Supplier` **asynchronously**, via
`Util.backgroundExecutor().execute(...)`:

```java
public static void register() {
    // Get main thread and use it to register our game rules early
    GAME_RULES.forEach(gameRule -> Util.backgroundExecutor().execute(gameRule::get));
}
```

Despite the comment, this does not run on the main thread — it's
dispatched to a background executor with no guarantee it completes
before a level's `GameRules` instance is built. When the timing loses
the race, the rule isn't registered yet, and any code reading it
(e.g. `TFPortalBlock`) throws a `NullPointerException`:

```java
level.getGameRules().getInt(TFGameRules.RULE_PLAYERS_TF_PORTAL_DEFAULT_DELAY.get())
```

This is intermittent and timing-dependent, which is why it doesn't
reproduce on every launch — it's more likely to surface on dedicated
servers with many mods competing for the background executor at
startup.

## Fix

Register the game rules synchronously instead, which is cheap (just
map insertion) and matches the original intent of the comment ("register
early" on the relevant thread before any level loads):

```java
public static void register() {
	GAME_RULES.forEach(Supplier::get);
}
```

## Testing

- Reproduced the NPE on a dedicated server build prior to the fix
  (crash on joining via a Twilight Forest portal)
- Confirmed the crash no longer occurs after the fix across multiple
  server restarts