### PR TITLE
Fix items 26.x

### DIFF
--- a/src/main/java/twilightforest/item/PeacockFanItem.java
+++ b/src/main/java/twilightforest/item/PeacockFanItem.java
@@ -95,7 +95,7 @@ public class PeacockFanItem extends Item {
 
 	@Override
 	public ItemUseAnimation getUseAnimation(ItemStack stack) {
-		return ItemUseAnimation.BLOCK;
+		return ItemUseAnimation.NONE;
 	}
 
 	@Override


### PR DESCRIPTION
This Pull Request corresponds to #2614 but targets the latest branch.

### Changes
- **Peacock Fan**: Removed the outdated `UseAnim.BLOCK` that was causing the item to freeze awkwardly in front of the player's face like a 1.8 blocking sword.

### Fixes
- Fixes #2412
