### PR TITLE
Fix entities 26.x

### DIFF
--- a/src/main/java/twilightforest/client/renderer/entity/MinotaurRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/entity/MinotaurRenderer.java
@@ -2,6 +2,7 @@ package twilightforest.client.renderer.entity;
 
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.HumanoidMobRenderer;
+import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
 import net.minecraft.resources.Identifier;
 import twilightforest.TwilightForestMod;
@@ -15,11 +16,18 @@ public class MinotaurRenderer extends HumanoidMobRenderer<Minotaur, HumanoidRend
 
 	public MinotaurRenderer(EntityRendererProvider.Context context) {
 		super(context, new MinotaurModel(context.bakeLayer(TFModelLayers.MINOTAUR)), 0.625F);
+		this.addLayer(new ItemInHandLayer<>(this));
 	}
 
 	@Override
 	public HumanoidRenderState createRenderState() {
 		return new HumanoidRenderState();
+	}
+
+	@Override
+	public void extractRenderState(Minotaur entity, HumanoidRenderState state, float partialTicks) {
+		super.extractRenderState(entity, state, partialTicks);
+		HumanoidRenderState.extractArmedEntityRenderState(entity, state, this.itemModelResolver, partialTicks);
 	}
 
 	@Override

--- a/src/main/java/twilightforest/client/renderer/entity/UnstableIceCoreRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/entity/UnstableIceCoreRenderer.java
@@ -25,13 +25,14 @@ public class UnstableIceCoreRenderer extends MobRenderer<UnstableIceCore, Living
 		stack.translate(0.0F, Mth.sin(state.ageInTicks * 0.2F) * 0.15F, 0.0F);
 
 		// flash
-		float f1 = state.deathTime;
-		if (f1 > 0) {
-			float f2 = 1.0F + Mth.sin(f1 * 100.0F) * f1 * 0.01F;
+		if (state.deathTime > 0) {
+			float f1 = state.deathTime / 60.0F;
 
 			if (f1 > 1.0F) {
 				f1 = 1.0F;
 			}
+
+			float f2 = 1.0F + Mth.sin(f1 * 60 * 100.0F) * f1 * 0.01F;
 
 			f1 *= f1;
 			f1 *= f1;

--- a/src/main/java/twilightforest/entity/ai/goal/HeavySpearAttackGoal.java
+++ b/src/main/java/twilightforest/entity/ai/goal/HeavySpearAttackGoal.java
@@ -9,6 +9,7 @@ import java.util.EnumSet;
 public class HeavySpearAttackGoal extends Goal {
 
 	private final UpperGoblinKnight entity;
+	private boolean hasAttackedInThisCycle = false;
 
 	@SuppressWarnings("this-escape")
 	public HeavySpearAttackGoal(UpperGoblinKnight upperKnight) {
@@ -17,9 +18,15 @@ public class HeavySpearAttackGoal extends Goal {
 	}
 
 	@Override
+	public void start() {
+		this.hasAttackedInThisCycle = false;
+	}
+
+	@Override
 	public void tick() {
-		if (this.entity.heavySpearTimer == 25) {
+		if (this.entity.heavySpearTimer <= 25 && !hasAttackedInThisCycle) {
 			this.entity.landHeavySpearAttack();
+			hasAttackedInThisCycle = true;
 		}
 	}
 

--- a/src/main/java/twilightforest/entity/boss/Hydra.java
+++ b/src/main/java/twilightforest/entity/boss/Hydra.java
@@ -192,7 +192,7 @@ public class Hydra extends BaseTFBoss {
 		double dx, dy, dz;
 
 		// body goes behind the actual position of the hydra
-		angle = (((this.yBodyRot + 180.0F) * Mth.PI) / 180.0F);
+		angle = (this.yBodyRot + 180.0F) * Mth.DEG_TO_RAD;
 
 		dx = this.getX() - Mth.sin(angle) * 3.0D;
 		dy = this.getY() + 0.1D;
@@ -244,7 +244,7 @@ public class Hydra extends BaseTFBoss {
 	private void activateHeadsOnLoad(byte heads) {
 		for (int i = 0; i < MAX_HEADS; i++) {
 			if ((heads & 1 << i) != 0) {
-				this.hc[i].setNextState(HydraHeadContainer.State.IDLE);
+				this.hc[i].forceAtcive();
 				this.hc[i].endCurrentAction();
 			}
 		}

--- a/src/main/java/twilightforest/entity/boss/HydraHeadContainer.java
+++ b/src/main/java/twilightforest/entity/boss/HydraHeadContainer.java
@@ -181,17 +181,9 @@ public class HydraHeadContainer {
 		this.setupStateRotations();
 
 		if (startActive) {
-			this.prevState = State.IDLE;
-			this.currentState = State.IDLE;
-			this.nextState = NEXT_AUTOMATIC;
-			this.ticksNeeded = 60;
-			this.ticksProgress = 60;
+			this.forceActive();
 		} else {
-			this.prevState = State.DEAD;
-			this.currentState = State.DEAD;
-			this.nextState = NEXT_AUTOMATIC;
-			this.ticksNeeded = 20;
-			this.ticksProgress = 20;
+			this.forceInactive();
 		}
 		this.setHeadPosition();
 		this.setNeckPosition();
@@ -317,6 +309,22 @@ public class HydraHeadContainer {
 		this.setAnimation(4, State.ROAR_RAWR, 50, -90, 10, 1);
 		this.setAnimation(5, State.ROAR_RAWR, -10, 90, 11, 1);
 		this.setAnimation(6, State.ROAR_RAWR, -10, -90, 11, 1);
+	}
+
+	public void forceActive() {
+		this.prevState = State.IDLE;
+		this.currentState = State.IDLE;
+		this.nextState = NEXT_AUTOMATIC;
+		this.ticksNeeded = 60;
+		this.ticksProgress = 60;
+	}
+
+	private void forceInactive() {
+		this.prevState = State.DEAD;
+		this.currentState = State.DEAD;
+		this.nextState = NEXT_AUTOMATIC;
+		this.ticksNeeded = 20;
+		this.ticksProgress = 20;
 	}
 
 	private void setAnimation(int head, State state, float xRotation, float yRotation, float neckLength, float mouthOpen) {

--- a/src/main/java/twilightforest/entity/monster/UpperGoblinKnight.java
+++ b/src/main/java/twilightforest/entity/monster/UpperGoblinKnight.java
@@ -45,7 +45,7 @@ public class UpperGoblinKnight extends Monster {
 	private static final EntityDataAccessor<Boolean> SHIELD_DISABLED = SynchedEntityData.defineId(UpperGoblinKnight.class, EntityDataSerializers.BOOLEAN);
 
 	private static final AttributeModifier ARMOR_MODIFIER = new AttributeModifier(TwilightForestMod.prefix("armor_boost"), 20, AttributeModifier.Operation.ADD_VALUE);
-	private static final AttributeModifier DAMAGE_MODIFIER = new AttributeModifier(TwilightForestMod.prefix("spear_attack_boost"), 12, AttributeModifier.Operation.ADD_MULTIPLIED_BASE);
+	private static final AttributeModifier DAMAGE_MODIFIER = new AttributeModifier(TwilightForestMod.prefix("spear_attack_boost"), 12, AttributeModifier.Operation.ADD_VALUE);
 	public static final int HEAVY_SPEAR_TIMER_START = 60;
 
 	private int shieldHits = 0;


### PR DESCRIPTION
This pull request corresponds to #2615 and #2616 but targets the latest branch.

### Changes
#### Minotaur:
* **MinotaurRenderer**: Registered `ItemInHandLayer` and overrode `extractRenderState` with `ItemModelResolver` to properly sync and render main-hand weapons on the 1.21.4 engine.
* **Minotaur**: Standardized the main-hand weapon drop chance to the vanilla default (`0.085F`).
#### Hydra:
* **HydraHeadContainer**: Introduced `forceActive()` and `forceInactive()` states to properly reset animation ticks and bitmasks, fixing client-side head invisibility upon player respawn or tracking reloads.
* **Hydra**: Updated `activateHeadsOnLoad` to leverage the new force-activation logic.
#### Unstable Ice Core:
* **UnstableIceCoreRenderer**: Fixed model stretching ("chewing gum effect") by normalizing `state.deathTime` (dividing by `60.0F`) into a smooth `0.0-1.0` progress range.
* **UnstableIceCoreRenderer**: Restored the intentional pre-explosion micro-vibrations based on the normalized death progress.
#### Upper Goblin Knight:
* Changed AttributeModifier operation to ADD_VALUE to fix the 104 damage bug.
* Switched to livingEntity.hurtServer to properly calculate armor and protection enchantments.
* Replaced fragile "== 25" tick check in HeavySpearAttackGoal with a reliable boolean flag to prevent tick-skipping bugs during server lag.

Fixes #2415
Fixes #2434
Fixes #2416
Fixes #2609