### PR TITLE
Fixed Various Projectile Problem and Entity Passenger Attachment

### DIFF
--- a/src/main/java/twilightforest/client/renderer/entity/ThrownWepRenderer.java
+++ b/src/main/java/twilightforest/client/renderer/entity/ThrownWepRenderer.java
@@ -36,7 +36,7 @@ public class ThrownWepRenderer extends EntityRenderer<ThrownWep, ThrownWepRender
 		stack.translate(-f9, -f10, -(f12 + f11));
 		stack.translate(0.0F, 0.0F, f12 + f11);
 
-		if (state.item.isEmpty()) {
+		if (!state.item.isEmpty()) {
 			state.item.submit(stack, collector, state.lightCoords, OverlayTexture.NO_OVERLAY, state.outlineColor);
 		}
 		stack.popPose();

--- a/src/main/java/twilightforest/entity/boss/AlphaYeti.java
+++ b/src/main/java/twilightforest/entity/boss/AlphaYeti.java
@@ -42,8 +42,8 @@ import twilightforest.entity.ai.goal.YetiTiredGoal;
 import twilightforest.entity.projectile.FallingIce;
 import twilightforest.entity.projectile.IceBomb;
 import twilightforest.init.*;
-import twilightforest.util.entities.EntityUtil;
 import twilightforest.util.WorldUtil;
+import twilightforest.util.entities.EntityUtil;
 
 public class AlphaYeti extends BaseTFBoss implements RangedAttackMob, IHostileMount {
 
@@ -206,7 +206,7 @@ public class AlphaYeti extends BaseTFBoss implements RangedAttackMob, IHostileMo
 
 	@Override
 	protected Vec3 getPassengerAttachmentPoint(Entity entity, EntityDimensions dimensions, float yRot) {
-		return new Vec3(0.0F, dimensions.height(), 0.4F);
+		return super.getPassengerAttachmentPoint(entity, dimensions, yRot).add(0.0F, 0F, 0.4F);
 	}
 
 	@Override

--- a/src/main/java/twilightforest/entity/monster/KingSpider.java
+++ b/src/main/java/twilightforest/entity/monster/KingSpider.java
@@ -78,6 +78,6 @@ public class KingSpider extends Spider {
 
 	@Override
 	protected Vec3 getPassengerAttachmentPoint(Entity entity, EntityDimensions dimensions, float yRot) {
-		return new Vec3(0.0F, dimensions.height() * 0.85F, 0.0F);
+		return super.getPassengerAttachmentPoint(entity, dimensions, yRot).add(0.0F, dimensions.height() * 0.15F, 0.0F);
 	}
 }

--- a/src/main/java/twilightforest/entity/monster/LowerGoblinKnight.java
+++ b/src/main/java/twilightforest/entity/monster/LowerGoblinKnight.java
@@ -122,7 +122,7 @@ public class LowerGoblinKnight extends Monster {
 
 	@Override
 	protected Vec3 getPassengerAttachmentPoint(Entity entity, EntityDimensions dimensions, float yRot) {
-		return new Vec3(0.0F, dimensions.height() * 0.91F, 0.0F);
+		return super.getPassengerAttachmentPoint(entity, dimensions, yRot).add(0.0F, dimensions.height() * 0.09F, 0.0F);
 	}
 
 	@Override

--- a/src/main/java/twilightforest/entity/monster/PinchBeetle.java
+++ b/src/main/java/twilightforest/entity/monster/PinchBeetle.java
@@ -143,7 +143,7 @@ public class PinchBeetle extends Monster implements IHostileMount {
 
 	@Override
 	protected Vec3 getPassengerAttachmentPoint(Entity entity, EntityDimensions dimensions, float yRot) {
-		return new Vec3(0.0F, this.getEyeHeight(), 0.75F);
+		return super.getPassengerAttachmentPoint(entity, dimensions, yRot).add(0.0F, -dimensions.height() + this.getEyeHeight(), 0.75F);
 	}
 
 	@Override

--- a/src/main/java/twilightforest/entity/monster/Troll.java
+++ b/src/main/java/twilightforest/entity/monster/Troll.java
@@ -244,6 +244,7 @@ public class Troll extends Monster implements RangedAttackMob {
 			double d1 = target.getBoundingBox().minY + target.getBbHeight() / 3.0F - blocc.getY();
 			double d2 = target.getZ() - this.getZ();
 			double d3 = Mth.sqrt((float) (d0 * d0 + d2 * d2));
+			blocc.setPos(this.getX(), this.getY() + this.getBbHeight(), this.getZ());
 			blocc.shoot(d0, d1 + d3 * 0.2D, d2, 1.6F, 4 - this.level().getDifficulty().getId());
 
 			this.playSound(TFSounds.TROLL_THROWS_ROCK.get(), 1.0F, 1.0F / (this.getRandom().nextFloat() * 0.4F + 0.8F));
@@ -251,7 +252,7 @@ public class Troll extends Monster implements RangedAttackMob {
 			this.level().addFreshEntity(blocc);
 			this.setHasRock(false);
 			if (!this.getPassengers().isEmpty() && Objects.requireNonNull(this.getFirstPassenger()).getType() == TFEntities.THROWN_BLOCK.get()) {
-				this.ejectPassengers();
+				this.getFirstPassenger().discard();
 			}
 			this.rockCooldown = 300 + this.getRandom().nextInt(100);
 			this.rock = null;

--- a/src/main/java/twilightforest/entity/monster/Troll.java
+++ b/src/main/java/twilightforest/entity/monster/Troll.java
@@ -116,7 +116,9 @@ public class Troll extends Monster implements RangedAttackMob {
 						this.setHasRock(true);
 						this.playSound(TFSounds.TROLL_GRABS_ROCK.get());
 						ThrownBlock block = new ThrownBlock(level, this.rock);
-						block.startRiding(this);
+						block.setPos(this.getX(), this.getY() + this.getBbHeight(), this.getZ());
+
+						block.startRiding(this, true, false);
 						level.addFreshEntity(block);
 					}
 				}
@@ -124,9 +126,10 @@ public class Troll extends Monster implements RangedAttackMob {
 		}
 	}
 
+
 	@Override
 	protected Vec3 getPassengerAttachmentPoint(Entity entity, EntityDimensions dimensions, float yRot) {
-		return new Vec3(0.0F, dimensions.height() * 1.25F, 0.0F);
+		return super.getPassengerAttachmentPoint(entity, dimensions, yRot).add(0.0F, dimensions.height() * 0.25F, 0.0F);
 	}
 
 	@Override
@@ -248,7 +251,7 @@ public class Troll extends Monster implements RangedAttackMob {
 			this.level().addFreshEntity(blocc);
 			this.setHasRock(false);
 			if (!this.getPassengers().isEmpty() && Objects.requireNonNull(this.getFirstPassenger()).getType() == TFEntities.THROWN_BLOCK.get()) {
-				this.getFirstPassenger().discard();
+				this.ejectPassengers();
 			}
 			this.rockCooldown = 300 + this.getRandom().nextInt(100);
 			this.rock = null;

--- a/src/main/java/twilightforest/entity/monster/Yeti.java
+++ b/src/main/java/twilightforest/entity/monster/Yeti.java
@@ -139,7 +139,7 @@ public class Yeti extends Monster implements IHostileMount {
 
 	@Override
 	protected Vec3 getPassengerAttachmentPoint(Entity entity, EntityDimensions dimensions, float yRot) {
-		return new Vec3(0.0F, dimensions.height(), 0.4F);
+		return super.getPassengerAttachmentPoint(entity, dimensions, yRot).add(0.0F, 0, 0.4F);
 	}
 
 	@Override

--- a/src/main/java/twilightforest/entity/projectile/ThrownBlock.java
+++ b/src/main/java/twilightforest/entity/projectile/ThrownBlock.java
@@ -4,17 +4,15 @@ import net.minecraft.core.particles.BlockParticleOption;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
-import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
-import net.minecraft.server.level.ServerEntity;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.EntityEvent;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.gameevent.GameEvent;
@@ -29,7 +27,7 @@ import twilightforest.init.TFEntities;
 
 public class ThrownBlock extends TFThrowable {
 
-	private BlockState state = Blocks.STONE.defaultBlockState();
+	private static final EntityDataAccessor<BlockState> DATA_BLOCK_STATE_ID = SynchedEntityData.defineId(ThrownBlock.class, EntityDataSerializers.BLOCK_STATE);
 
 	public ThrownBlock(EntityType<? extends TFThrowable> type, Level worldIn) {
 		super(type, worldIn);
@@ -38,8 +36,14 @@ public class ThrownBlock extends TFThrowable {
 	public ThrownBlock(Level world, @Nullable BlockState state) {
 		super(TFEntities.THROWN_BLOCK.get(), world);
 		if (state != null) {
-			this.state = state;
+			this.setBlockState(state);
 		}
+	}
+
+	@Override
+	protected void defineSynchedData(SynchedEntityData.Builder entityData) {
+		super.defineSynchedData(entityData);
+		entityData.define(DATA_BLOCK_STATE_ID, Blocks.STONE.defaultBlockState());
 	}
 
 	@Override
@@ -50,19 +54,19 @@ public class ThrownBlock extends TFThrowable {
 	@Override
 	protected void addAdditionalSaveData(ValueOutput tag) {
 		super.addAdditionalSaveData(tag);
-		tag.store("BlockState", BlockState.CODEC, this.state);
+		tag.store("BlockState", BlockState.CODEC, this.getBlockState());
 	}
 
 	@Override
 	protected void readAdditionalSaveData(ValueInput tag) {
 		super.readAdditionalSaveData(tag);
-		this.state = tag.read("BlockState", BlockState.CODEC).orElse(Blocks.AIR.defaultBlockState());
+		this.setBlockState(tag.read("BlockState", BlockState.CODEC).orElse(Blocks.STONE.defaultBlockState()));
 	}
 
 	@Override
 	public void handleEntityEvent(byte id) {
 		if (id == EntityEvent.DEATH) {
-			ParticleOptions particle = new BlockParticleOption(ParticleTypes.BLOCK, this.state);
+			ParticleOptions particle = new BlockParticleOption(ParticleTypes.BLOCK, this.getBlockState());
 			for (int i = 0; i < 20; i++) {
 				this.level().addParticle(particle, this.getX(), this.getY(), this.getZ(), this.random.nextGaussian() * 0.05D, this.random.nextDouble() * 0.2D, this.random.nextGaussian() * 0.05D);
 			}
@@ -92,23 +96,16 @@ public class ThrownBlock extends TFThrowable {
 		}
 	}
 
-	public BlockState getBlockState() {
-		return this.state;
+	public void setBlockState(BlockState blockState) {
+		this.entityData.set(DATA_BLOCK_STATE_ID, blockState);
 	}
 
-	@Override
-	public Packet<ClientGamePacketListener> getAddEntityPacket(ServerEntity entity) {
-		return new ClientboundAddEntityPacket(this, entity, Block.getId(this.getBlockState()));
+	public BlockState getBlockState() {
+		return this.entityData.get(DATA_BLOCK_STATE_ID);
 	}
 
 	@Override
 	public Component getTypeName() {
 		return this.getBlockState().getBlock().getName();
-	}
-
-	@Override
-	public void recreateFromPacket(ClientboundAddEntityPacket packet) {
-		super.recreateFromPacket(packet);
-		this.state = Block.stateById(packet.getData());
 	}
 }

--- a/src/main/java/twilightforest/entity/projectile/ThrownWep.java
+++ b/src/main/java/twilightforest/entity/projectile/ThrownWep.java
@@ -38,6 +38,7 @@ public class ThrownWep extends TFThrowable {
 
 	@Override
 	protected void defineSynchedData(SynchedEntityData.Builder builder) {
+		super.defineSynchedData(builder);
 		builder.define(DATA_ITEMSTACK, ItemStack.EMPTY);
 		builder.define(DATA_VELOCITY, 0.001F);
 	}

--- a/src/main/java/twilightforest/entity/projectile/ThrownWep.java
+++ b/src/main/java/twilightforest/entity/projectile/ThrownWep.java
@@ -8,7 +8,6 @@ import net.minecraft.world.entity.EntityEvent;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -17,8 +16,6 @@ import twilightforest.init.TFDamageTypes;
 import twilightforest.init.TFItems;
 
 public class ThrownWep extends TFThrowable {
-
-	private static final EntityDataAccessor<ItemStack> DATA_ITEMSTACK = SynchedEntityData.defineId(ThrownWep.class, EntityDataSerializers.ITEM_STACK);
 	private static final EntityDataAccessor<Float> DATA_VELOCITY = SynchedEntityData.defineId(ThrownWep.class, EntityDataSerializers.FLOAT);
 
 	private float projectileDamage = 6;
@@ -39,22 +36,13 @@ public class ThrownWep extends TFThrowable {
 	@Override
 	protected void defineSynchedData(SynchedEntityData.Builder builder) {
 		super.defineSynchedData(builder);
-		builder.define(DATA_ITEMSTACK, ItemStack.EMPTY);
 		builder.define(DATA_VELOCITY, 0.001F);
 	}
 
-	public ThrownWep setCurrentItem(ItemStack stack) {
-		this.getEntityData().set(DATA_ITEMSTACK, stack);
-		return this;
-	}
 
 	@Override
 	protected Item getDefaultItem() {
 		return TFItems.KNIGHTMETAL_SWORD.asItem();
-	}
-
-	public ItemStack getItem() {
-		return this.getEntityData().get(DATA_ITEMSTACK);
 	}
 
 	public ThrownWep setVelocity(float velocity) {

--- a/src/main/java/twilightforest/item/ChainBlockItem.java
+++ b/src/main/java/twilightforest/item/ChainBlockItem.java
@@ -55,6 +55,7 @@ public class ChainBlockItem extends Item {
 
 		if (!level.isClientSide()) {
 			ChainBlock launchedBlock = new ChainBlock(TFEntities.CHAIN_BLOCK.get(), level, player, hand, stack);
+			launchedBlock.setOwner(player);
 			level.addFreshEntity(launchedBlock);
 			stack.set(TFDataComponents.THROWN_PROJECTILE, launchedBlock.getUUID());
 		}


### PR DESCRIPTION
While Passenger Attachment could be handled with EntityType, I kept its form because the entity using it has a special way of utilizing passenger.
Also, the previous method using getPassengerAttachmentPoint fixed the position to the center of the world, so I've modified it to follow the object's position.

- Fixed Passenger Attachment(Looks like old one has making Lower Position For Rider)
- Fixed Thrown Weapon Projectile not render the item
- Thrown Weapon now use to ThrowableItemProjectile's method
- Fixed chain block entity disappeard because Owner has not set
- Fixed Thrown Block not appear to correct position (include troll holding one)