### PR TITLE
Port missing sprite fallback logic in GhastTearParticle

### DIFF
--- a/src/main/java/twilightforest/client/particle/GhastTearParticle.java
+++ b/src/main/java/twilightforest/client/particle/GhastTearParticle.java
@@ -6,12 +6,12 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.SingleQuadParticle;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
-import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
-import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.sprite.Material;
 import net.minecraft.core.particles.ItemParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.data.AtlasIds;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemDisplayContext;
@@ -59,21 +59,15 @@ public class GhastTearParticle extends SingleQuadParticle {
 	public static class Factory implements ParticleProvider<SimpleParticleType> {
 		@Override
 		public Particle createParticle(SimpleParticleType type, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed, RandomSource random) {
-			TextureAtlasSprite textureatlassprite = this.calculateState(new ItemStack(Items.GHAST_TEAR), level).pickParticleMaterial(random).sprite();
-
-//			if (textureatlassprite == null) {
-//				textureatlassprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(MissingTextureAtlasSprite.getLocation());
-//			}
-
-			return new GhastTearParticle(level, x, y, z, textureatlassprite);
+			return new GhastTearParticle(level, x, y, z, this.getSprite(new ItemStackTemplate(Items.GHAST_TEAR), level, random));
 		}
 
-		protected ItemStackRenderState calculateState(ItemStack stack, ClientLevel level) {
+		// [VanillaCopy] BreakingItemParticle$ItemParticleProvider#getSprite(ItemStackTemplate, ClientLevel, RandomSource);
+		protected TextureAtlasSprite getSprite(ItemStackTemplate item, ClientLevel level, RandomSource random) {
 			var state = new ItemStackRenderState();
-			Minecraft.getInstance()
-				.getItemModelResolver()
-				.updateForTopItem(state, stack, ItemDisplayContext.GROUND, level, null, 0);
-			return state;
+			Minecraft.getInstance().getItemModelResolver().updateForTopItem(state, item.create(), ItemDisplayContext.GROUND, level, null, 0);
+			Material.Baked material = state.pickParticleMaterial(random);
+			return material != null ? material.sprite() : Minecraft.getInstance().getAtlasManager().getAtlasOrThrow(AtlasIds.ITEMS).missingSprite();
 		}
 	}
 }


### PR DESCRIPTION
This replaces the commented out code with a new fallback matching current vanilla standards.